### PR TITLE
Remove stye inconsistencies in text rendering

### DIFF
--- a/src/components/MarkdownPreview.jsx
+++ b/src/components/MarkdownPreview.jsx
@@ -13,14 +13,14 @@ export default function MarkdownPreview({ text, preprocessMarkdown }) {
             if (!children || (Array.isArray(children) && children.length === 0)) {
               return <div className="h-6" />;
             }
-            return <p className="mb-6 text-lg leading-relaxed text-gray-700 dark:text-gray-300 text-justify font-light font-sans preview-paragraph">{children}</p>;
+            return <p className="mb-6 text-lg leading-relaxed text-gray-700 dark:text-gray-300 text-justify font-light preview-paragraph">{children}</p>;
           },
-          h1: ({ children }) => <h1 className="text-4xl font-normal text-gray-900 dark:text-gray-100 mb-8 mt-2 text-center preview-h1">{children}</h1>,
-          h2: ({ children }) => <h2 className="text-3xl font-normal text-gray-900 dark:text-gray-100 mb-6 mt-8 preview-h2">{children}</h2>,
-          h3: ({ children }) => <h3 className="text-2xl font-normal text-gray-900 dark:text-gray-100 mb-4 mt-6 preview-h3">{children}</h3>,
-          h4: ({ children }) => <h4 className="text-xl font-normal text-gray-900 dark:text-gray-100 mb-3 mt-4 preview-h4">{children}</h4>,
-          h5: ({ children }) => <h5 className="text-lg font-normal text-gray-900 dark:text-gray-100 mb-3 mt-4 preview-h5">{children}</h5>,
-          h6: ({ children }) => <h6 className="text-base font-normal text-gray-900 dark:text-gray-100 mb-3 mt-4 preview-h6">{children}</h6>,
+          h1: ({ children }) => <h1 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-8 mt-2 text-center preview-h1">{children}</h1>,
+          h2: ({ children }) => <h2 className="text-3xl font-semibold text-gray-900 dark:text-gray-100 mb-6 mt-8 preview-h2">{children}</h2>,
+          h3: ({ children }) => <h3 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mb-4 mt-6 preview-h3">{children}</h3>,
+          h4: ({ children }) => <h4 className="text-xl font-medium text-gray-900 dark:text-gray-100 mb-3 mt-4 preview-h4">{children}</h4>,
+          h5: ({ children }) => <h5 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-3 mt-4 preview-h5">{children}</h5>,
+          h6: ({ children }) => <h6 className="text-base font-medium text-gray-900 dark:text-gray-100 mb-3 mt-4 preview-h6">{children}</h6>,
           ul: ({ children }) => <ul className="mb-6 list-disc pl-6 space-y-2 text-lg text-gray-700 dark:text-gray-300 font-light">{children}</ul>,
           ol: ({ children }) => <ol className="mb-6 list-decimal pl-6 space-y-2 text-lg text-gray-700 dark:text-gray-300 font-light">{children}</ol>,
           li: ({ children }) => <li className="leading-relaxed preview-li">{children}</li>,

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -103,58 +103,7 @@ textarea:focus {
   font-feature-settings: "kern" 1, "liga" 1;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
-}
-
-/* Explicit heading styles to ensure they render properly */
-.prose h1 {
-  font-size: 2.25rem !important;
-  font-weight: 700 !important;
-  line-height: 2.5rem !important;
-  margin-bottom: 2rem !important;
-  margin-top: 0 !important;
-  color: #111827 !important;
-}
-
-.dark .prose h1 {
-  color: #f9fafb !important;
-}
-
-.prose h2 {
-  font-size: 1.875rem !important;
-  font-weight: 600 !important;
-  line-height: 2.25rem !important;
-  margin-bottom: 1.5rem !important;
-  margin-top: 3rem !important;
-  color: #111827 !important;
-}
-
-.dark .prose h2 {
-  color: #f9fafb !important;
-}
-
-.prose h3 {
-  font-size: 1.5rem !important;
-  font-weight: 500 !important;
-  line-height: 2rem !important;
-  margin-bottom: 1rem !important;
-  margin-top: 2.5rem !important;
-  color: #111827 !important;
-}
-
-.dark .prose h3 {
-  color: #f9fafb !important;
-}
-
-.prose p {
-  font-size: 1rem !important;
-  line-height: 1.75rem !important;
-  margin-bottom: 1.5rem !important;
-  color: #374151 !important;
-}
-
-.dark .prose p {
-  color: #d1d5db !important;
+  font-family: 'Avenir', 'Avenir Next', -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
 /* Code block styling */
@@ -260,7 +209,6 @@ textarea:focus {
 
 .preview-paragraph {
   line-height: 1.8;
-  font-family: 'Avenir', 'Avenir Next', -apple-system, sans-serif;
 }
 
 .preview-h1 {

--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -213,32 +213,26 @@ textarea:focus {
 
 .preview-h1 {
   line-height: 1.2;
-  font-weight: 400;
 }
 
 .preview-h2 {
   line-height: 1.3;
-  font-weight: 400;
 }
 
 .preview-h3 {
   line-height: 1.4;
-  font-weight: 400;
 }
 
 .preview-h4 {
   line-height: 1.4;
-  font-weight: 400;
 }
 
 .preview-h5 {
   line-height: 1.5;
-  font-weight: 400;
 }
 
 .preview-h6 {
   line-height: 1.5;
-  font-weight: 400;
 }
 
 .preview-li {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -59,31 +59,6 @@
   .card {
     @apply bg-white dark:bg-gray-800 rounded-xl shadow-md p-6 border border-gray-200 dark:border-gray-700;
   }
-
-  /* Enhanced markdown styles */
-  .prose h1 {
-    @apply text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6 mt-8;
-  }
-  
-  .prose h2 {
-    @apply text-2xl font-semibold text-gray-900 dark:text-gray-100 mb-4 mt-6;
-  }
-  
-  .prose h3 {
-    @apply text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3 mt-5;
-  }
-  
-  .prose h4 {
-    @apply text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2 mt-4;
-  }
-  
-  .prose h5 {
-    @apply text-base font-semibold text-gray-900 dark:text-gray-100 mb-2 mt-3;
-  }
-  
-  .prose h6 {
-    @apply text-sm font-semibold text-gray-900 dark:text-gray-100 mb-2 mt-3;
-  }
 }
 
 @layer utilities {


### PR DESCRIPTION
# Merge Request: Fix Text Rendering Inconsistencies in Preview Mode

## Overview

**Type:** Bug Fix
**Priority:** Medium
**Branch:** `develop`
**Target:** `main`

## Problem Statement

Text in preview mode rendered with inconsistent size and weight between different element types:

- **Paragraphs** displayed at 16px
- **List items** displayed at 18px
- Font weights appeared different between elements
- Visual inconsistency created poor reading experience

### Root Cause

Conflicting CSS rules created a specificity war:

1. `editor.css` contained `!important` overrides forcing paragraphs to 16px
2. `MarkdownPreview.jsx` applied `text-lg` (18px) via Tailwind classes
3. List items had no `!important` override, so they respected the 18px size
4. Duplicate heading styles across `index.css` and `editor.css` created additional conflicts

## Solution

Established **single source of truth** architecture for typography:

- Removed all `!important` CSS overrides that caused conflicts
- Made `MarkdownPreview.jsx` component the primary styling source via Tailwind classes
- Updated `.prose` base class to use Avenir font family consistently
- Simplified custom CSS to only handle line-height fine-tuning
- Updated heading font weights for proper visual hierarchy

## Changes Made

### 1. `src/styles/editor.css`

**Removed:**
- Lines 110-147: All heading `!important` rules (`.prose h1` through `.prose h3` and dark mode variants)
- Lines 149-158: Paragraph `!important` rules (`.prose p` and `.dark .prose p`)

**Updated:**
- `.prose` base class (lines 102-107): Changed font-family to `'Avenir', 'Avenir Next', -apple-system, BlinkMacSystemFont, sans-serif`
- `.preview-paragraph` (lines 261-263): Simplified to only control `line-height: 1.8`

### 2. `src/components/MarkdownPreview.jsx`

**Updated:**
- Paragraph component (line 16): Removed `font-sans` class (now inherits from `.prose`)
- Heading components (lines 18-23): Updated font weights:
  - `h1`: `font-bold` (700 weight)
  - `h2-h3`: `font-semibold` (600 weight)
  - `h4-h6`: `font-medium` (500 weight)

### 3. `src/styles/index.css`

**Removed:**
- Lines 64-86: Duplicate heading utility classes in `@layer components` section
- Entire `/* Enhanced markdown styles */` block that conflicted with component styles

## Expected Outcome

After these changes:

✅ **Paragraphs** render at 18px (matching list items)
✅ **Font weight** is consistent at 300 (light) for body text
✅ **Line-height** is 1.8 for both paragraphs and list items
✅ **Font family** is Avenir for all text (inherited from `.prose`)
✅ **Dark mode** colors work correctly
✅ **Headings** display proper visual hierarchy
✅ **No CSS specificity conflicts** remain

## Testing Instructions

### Manual Testing

1. **Start the development server:**
   ```bash
   npm run dev
   ```

2. **Open the application** at `http://localhost:3000/`

3. **Create test markdown content:**
   ```markdown
   # Heading 1

   This is a paragraph with regular text that should match list items in size and weight.

   ## Heading 2

   Another paragraph to verify consistency.

   ### Security Considerations

   - **Security**: Executing JavaScript within Markdown can pose security risks
   - **Compatibility**: Not all Markdown parsers support JavaScript embedding
   - Lists should match paragraph text size exactly

   Regular paragraph text for comparison with the list above.
   ```

4. **Switch to Preview mode** and verify:
   - [ ] Paragraphs and list items are the same size (18px)
   - [ ] Font weight is consistent (light/300) for both
   - [ ] Line-height appears uniform (1.8)
   - [ ] Font family is Avenir for all body text
   - [ ] No jarring visual differences between element types

5. **Toggle dark mode** and verify:
   - [ ] Text colors work correctly in both modes
   - [ ] No visual regressions in dark mode

6. **Check heading hierarchy:**
   - [ ] H1 appears boldest
   - [ ] H2-H3 are semibold
   - [ ] H4-H6 are medium weight
   - [ ] Clear visual hierarchy from largest to smallest

7. **Verify other elements** (no regressions):
   - [ ] Code blocks render correctly
   - [ ] Blockquotes display properly
   - [ ] Tables work as expected
   - [ ] Links are styled correctly

### Visual Comparison

**Before:** Paragraphs at 16px, lists at 18px (inconsistent)
**After:** Both at 18px with matching weight and spacing (consistent)

## Architecture Improvements

This change establishes better architectural patterns:

1. **Single Source of Truth**: Component-level styling via Tailwind classes
2. **Minimal Custom CSS**: Only for properties Tailwind doesn't handle well
3. **No Specificity Wars**: Removed all `!important` overrides
4. **Inheritance Over Repetition**: Font-family set once, inherited everywhere
5. **Component Co-location**: Styles live with components, not scattered in CSS

## Backward Compatibility

**Breaking Changes:** None

**Migration Required:** None

This change only affects the visual rendering consistency. No API changes, no prop changes, no functional behavior changes.

## Related Issues

Fixes text rendering inconsistencies observed in preview mode where paragraphs and lists appeared with different sizes and weights.

## Checklist

- [x] Code changes completed
- [x] Files updated (editor.css, MarkdownPreview.jsx, index.css)
- [x] Development server tested successfully
- [ ] Manual testing completed by reviewer
- [ ] Dark mode verified
- [ ] No visual regressions confirmed
- [ ] Ready for merge
