### PR TITLE
Fix DocumentState immutability with useReducer

### DIFF
--- a/src/contexts/AgentContext.jsx
+++ b/src/contexts/AgentContext.jsx
@@ -1,28 +1,66 @@
 /**
  * Agent Context
  *
- * React context for managing the multi-agent editorial system
+ * React context for managing the multi-agent editorial system.
+ * Uses useReducer with immutable document state for correct React updates.
  */
 
-import { createContext, useContext, useState, useEffect, useCallback } from 'react'
-import { DocumentState } from '../services/agents/documentState'
+import { createContext, useContext, useState, useEffect, useCallback, useReducer, useRef } from 'react'
+import {
+  createDocumentState,
+  updateContent,
+  addChangeProposal as addChangeProposalFn,
+  approveProposal as approveProposalFn,
+  rejectProposal as rejectProposalFn,
+  approveAllFromAgent as approveAllFromAgentFn,
+  getChangeProposals,
+  getPendingProposals as getPendingProposalsFn,
+  getAnnotations,
+  DocumentState
+} from '../services/agents/documentState'
 import { initializeAgentSystem, getAllAgents, getAgentsByStage } from '../agents'
 import { getOrchestrator } from '../services/agents/orchestrator'
 
 const AgentContext = createContext()
 
+function documentReducer(state, action) {
+  switch (action.type) {
+    case 'INITIALIZE':
+      return createDocumentState(action.content, action.metadata)
+    case 'UPDATE_CONTENT':
+      return updateContent(state, action.content, action.source)
+    case 'APPROVE_PROPOSAL':
+      return approveProposalFn(state, action.proposalId)
+    case 'REJECT_PROPOSAL':
+      return rejectProposalFn(state, action.proposalId, action.reason)
+    case 'SYNC':
+      return action.state
+    default:
+      return state
+  }
+}
+
 export function AgentProvider({ children }) {
-  const [documentState, setDocumentState] = useState(null)
-  const [updateCounter, setUpdateCounter] = useState(0) // Force re-renders
+  const [docState, dispatch] = useReducer(documentReducer, null)
   const [orchestrator] = useState(() => getOrchestrator())
   const [agents, setAgents] = useState([])
   const [pipelines, setPipelines] = useState([])
-  const [changeProposals, setChangeProposals] = useState([])
-  const [annotations, setAnnotations] = useState([])
   const [isExecuting, setIsExecuting] = useState(false)
   const [currentStep, setCurrentStep] = useState(null)
   const [executionProgress, setExecutionProgress] = useState(null)
   const [selectedAgent, setSelectedAgent] = useState(null)
+
+  // Ref holding a DocumentState class wrapper for agent execution.
+  // Agents call methods on this (addChangeProposal, addAnnotation, etc.)
+  // and we sync the internal state back to the reducer after execution.
+  const wrapperRef = useRef(null)
+
+  // Keep wrapper in sync when reducer state changes from non-agent actions
+  useEffect(() => {
+    if (docState && wrapperRef.current) {
+      wrapperRef.current._state = docState
+    }
+  }, [docState])
 
   // Initialize agent system on mount
   useEffect(() => {
@@ -31,39 +69,34 @@ export function AgentProvider({ children }) {
     setPipelines(orchestrator.getAllPipelines())
   }, [orchestrator])
 
+  // Derive proposals and annotations from reducer state
+  const changeProposals = docState ? getChangeProposals(docState) : []
+  const annotations = docState ? getAnnotations(docState) : []
+
   /**
    * Initialize or update document state
    */
   const initializeDocument = useCallback((content, metadata = {}) => {
-    const state = new DocumentState(content, metadata)
-    setDocumentState(state)
-    updateProposalsAndAnnotations(state)
+    const wrapper = new DocumentState(content, metadata)
+    wrapperRef.current = wrapper
+    dispatch({ type: 'INITIALIZE', content, metadata })
   }, [])
 
   /**
    * Update document content
    */
   const updateDocumentContent = useCallback((content, source = 'user') => {
-    if (!documentState) return
-
-    documentState.updateContent(content, source)
-    setDocumentState(documentState) // Trigger re-render
-    updateProposalsAndAnnotations(documentState)
-  }, [documentState])
+    if (!docState) return
+    dispatch({ type: 'UPDATE_CONTENT', content, source })
+  }, [docState])
 
   /**
-   * Update proposals and annotations from document state
-   */
-  const updateProposalsAndAnnotations = useCallback((state) => {
-    setChangeProposals(state.getChangeProposals())
-    setAnnotations(state.getAnnotations())
-  }, [])
-
-  /**
-   * Execute a single agent
+   * Execute a single agent.
+   * Agents use the DocumentState class API (addChangeProposal, etc.),
+   * so we pass the wrapper ref and sync its state back afterward.
    */
   const executeAgent = useCallback(async (agentId, options = {}) => {
-    if (!documentState) {
+    if (!docState) {
       console.error('[AgentContext] No document initialized. DocumentState is null.')
       throw new Error('No document initialized')
     }
@@ -72,10 +105,11 @@ export function AgentProvider({ children }) {
     setExecutionProgress({ type: 'agent', agentId, status: 'running' })
 
     try {
-      const result = await orchestrator.executeAgent(agentId, documentState, options)
+      const wrapper = wrapperRef.current
+      const result = await orchestrator.executeAgent(agentId, wrapper, options)
 
-      // Update proposals and annotations
-      updateProposalsAndAnnotations(documentState)
+      // Sync agent mutations back to reducer
+      dispatch({ type: 'SYNC', state: wrapper._state })
 
       setExecutionProgress({ type: 'agent', agentId, status: 'completed', result })
       return result
@@ -86,13 +120,13 @@ export function AgentProvider({ children }) {
       setIsExecuting(false)
       setTimeout(() => setExecutionProgress(null), 3000)
     }
-  }, [documentState, orchestrator, updateProposalsAndAnnotations])
+  }, [docState, orchestrator])
 
   /**
    * Execute a pipeline
    */
   const executePipeline = useCallback(async (pipelineId, options = {}) => {
-    if (!documentState) {
+    if (!docState) {
       throw new Error('No document initialized')
     }
 
@@ -100,13 +134,15 @@ export function AgentProvider({ children }) {
     setExecutionProgress({ type: 'pipeline', pipelineId, status: 'running' })
 
     try {
-      const result = await orchestrator.executePipeline(pipelineId, documentState, {
+      const wrapper = wrapperRef.current
+      const result = await orchestrator.executePipeline(pipelineId, wrapper, {
         onStepStart: (stepIndex, step) => {
           setCurrentStep({ stepIndex, step, status: 'running' })
         },
         onStepComplete: (stepIndex, step, result) => {
           setCurrentStep({ stepIndex, step, status: 'completed', result })
-          updateProposalsAndAnnotations(documentState)
+          // Sync intermediate state so UI updates between pipeline steps
+          dispatch({ type: 'SYNC', state: wrapper._state })
         },
         onProgress: (stepIndex, data) => {
           setExecutionProgress({
@@ -120,6 +156,9 @@ export function AgentProvider({ children }) {
         ...options
       })
 
+      // Final sync
+      dispatch({ type: 'SYNC', state: wrapper._state })
+
       setExecutionProgress({ type: 'pipeline', pipelineId, status: 'completed', result })
       return result
     } catch (error) {
@@ -130,76 +169,70 @@ export function AgentProvider({ children }) {
       setCurrentStep(null)
       setTimeout(() => setExecutionProgress(null), 3000)
     }
-  }, [documentState, orchestrator, updateProposalsAndAnnotations])
+  }, [docState, orchestrator])
 
   /**
    * Approve a change proposal
    */
   const approveProposal = useCallback((proposalId) => {
-    if (!documentState) return
+    if (!docState) return
 
     try {
-      const newContent = documentState.approveProposal(proposalId)
-      // Force React to recognize the state change
-      setUpdateCounter(c => c + 1)
-      updateProposalsAndAnnotations(documentState)
-      return newContent
+      // Compute new state to get the resulting content
+      const newState = approveProposalFn(docState, proposalId)
+      dispatch({ type: 'SYNC', state: newState })
+      return newState.content
     } catch (error) {
       console.error('Failed to approve proposal:', error)
       throw error
     }
-  }, [documentState, updateProposalsAndAnnotations])
+  }, [docState])
 
   /**
    * Reject a change proposal
    */
   const rejectProposal = useCallback((proposalId, reason = '') => {
-    if (!documentState) return
+    if (!docState) return
 
     try {
-      documentState.rejectProposal(proposalId, reason)
-      // Force React to recognize the state change
-      setUpdateCounter(c => c + 1)
-      updateProposalsAndAnnotations(documentState)
+      dispatch({ type: 'REJECT_PROPOSAL', proposalId, reason })
     } catch (error) {
       console.error('Failed to reject proposal:', error)
       throw error
     }
-  }, [documentState, updateProposalsAndAnnotations])
+  }, [docState])
 
   /**
    * Approve all proposals from an agent
    */
   const approveAllFromAgent = useCallback((agentId) => {
-    if (!documentState) return
+    if (!docState) return
 
     try {
-      const results = documentState.approveAllFromAgent(agentId)
-      // Force React to recognize the state change
-      setUpdateCounter(c => c + 1)
-      updateProposalsAndAnnotations(documentState)
+      const { newState, results } = approveAllFromAgentFn(docState, agentId)
+      dispatch({ type: 'SYNC', state: newState })
       return results
     } catch (error) {
       console.error('Failed to approve all proposals:', error)
       throw error
     }
-  }, [documentState, updateProposalsAndAnnotations])
+  }, [docState])
 
   /**
    * Get pending proposals
    */
   const getPendingProposals = useCallback(() => {
-    if (!documentState) return []
-    return documentState.getPendingProposals()
-  }, [documentState])
+    if (!docState) return []
+    return getPendingProposalsFn(docState)
+  }, [docState])
 
   /**
    * Get proposals by filter
    */
   const getFilteredProposals = useCallback((filter) => {
-    if (!documentState) return []
-    return documentState.getChangeProposals(filter)
-  }, [documentState])
+    if (!docState) return []
+    return getChangeProposals(docState, filter)
+  }, [docState])
 
   /**
    * Cancel current execution
@@ -211,10 +244,15 @@ export function AgentProvider({ children }) {
     setExecutionProgress(null)
   }, [orchestrator])
 
+  // Expose the DocumentState wrapper for backward compatibility.
+  // Consumers (agents, tests) call methods on this object directly.
+  // Will be removed when consumers migrate to dispatch-based API (Phase 2.3).
+  const documentState = wrapperRef.current
+
   const value = {
     // State
     documentState,
-    updateCounter,
+    documentContent: docState ? docState.content : null,
     agents,
     pipelines,
     changeProposals,

--- a/src/contexts/__tests__/AgentContext.init.test.jsx
+++ b/src/contexts/__tests__/AgentContext.init.test.jsx
@@ -368,19 +368,19 @@ describe.skip('AgentContext - Initialization', () => {
   })
 
   describe('Context state exposure', () => {
-    test('exposes updateCounter', () => {
-      function CounterComponent() {
-        const { updateCounter } = useAgents()
-        return <span data-testid="counter">{updateCounter}</span>
+    test('exposes documentContent', () => {
+      function ContentComponent() {
+        const { documentContent } = useAgents()
+        return <span data-testid="content">{documentContent || 'none'}</span>
       }
 
       render(
         <AgentProvider>
-          <CounterComponent />
+          <ContentComponent />
         </AgentProvider>
       )
 
-      expect(screen.getByTestId('counter')).toHaveTextContent('0')
+      expect(screen.getByTestId('content')).toHaveTextContent('none')
     })
 
     test('exposes annotations', () => {

--- a/src/contexts/__tests__/AgentContext.proposals.test.jsx
+++ b/src/contexts/__tests__/AgentContext.proposals.test.jsx
@@ -75,13 +75,13 @@ describe.skip('AgentContext - Proposals', () => {
       expect(screen.getByTestId('content')).toHaveTextContent('Updated content')
     })
 
-    test('increments updateCounter', () => {
-      function CounterComponent() {
+    test('updates documentContent after approval', () => {
+      function ContentComponent() {
         const {
           initializeDocument,
           documentState,
           approveProposal,
-          updateCounter
+          documentContent
         } = useAgents()
 
         const addAndApproveProposal = () => {
@@ -102,7 +102,7 @@ describe.skip('AgentContext - Proposals', () => {
 
         return (
           <div>
-            <span data-testid="counter">{updateCounter}</span>
+            <span data-testid="content">{documentContent || 'none'}</span>
             <button onClick={() => initializeDocument('Test')}>Initialize</button>
             <button onClick={addAndApproveProposal}>Approve</button>
           </div>
@@ -111,17 +111,17 @@ describe.skip('AgentContext - Proposals', () => {
 
       render(
         <AgentProvider>
-          <CounterComponent />
+          <ContentComponent />
         </AgentProvider>
       )
 
-      const initialCounter = screen.getByTestId('counter').textContent
+      expect(screen.getByTestId('content')).toHaveTextContent('none')
 
       screen.getByText('Initialize').click()
-      screen.getByText('Approve').click()
+      expect(screen.getByTestId('content')).toHaveTextContent('Test')
 
-      const newCounter = screen.getByTestId('counter').textContent
-      expect(parseInt(newCounter)).toBeGreaterThan(parseInt(initialCounter))
+      screen.getByText('Approve').click()
+      expect(screen.getByTestId('content')).toHaveTextContent('New')
     })
 
     test('does nothing when documentState is null', () => {
@@ -230,13 +230,13 @@ describe.skip('AgentContext - Proposals', () => {
       expect(screen.getByTestId('rejected')).toHaveTextContent('1')
     })
 
-    test('increments updateCounter', () => {
-      function CounterComponent() {
+    test('updates changeProposals after rejection', () => {
+      function RejectComponent() {
         const {
           initializeDocument,
           documentState,
           rejectProposal,
-          updateCounter
+          changeProposals
         } = useAgents()
 
         const addAndRejectProposal = () => {
@@ -255,9 +255,11 @@ describe.skip('AgentContext - Proposals', () => {
           }
         }
 
+        const rejected = changeProposals.filter(p => p.status === 'rejected')
+
         return (
           <div>
-            <span data-testid="counter">{updateCounter}</span>
+            <span data-testid="rejected">{rejected.length}</span>
             <button onClick={() => initializeDocument('Test')}>Initialize</button>
             <button onClick={addAndRejectProposal}>Reject</button>
           </div>
@@ -266,17 +268,14 @@ describe.skip('AgentContext - Proposals', () => {
 
       render(
         <AgentProvider>
-          <CounterComponent />
+          <RejectComponent />
         </AgentProvider>
       )
-
-      const initialCounter = screen.getByTestId('counter').textContent
 
       screen.getByText('Initialize').click()
       screen.getByText('Reject').click()
 
-      const newCounter = screen.getByTestId('counter').textContent
-      expect(parseInt(newCounter)).toBeGreaterThan(parseInt(initialCounter))
+      expect(screen.getByTestId('rejected')).toHaveTextContent('1')
     })
 
     test('does nothing when documentState is null', () => {

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -44,7 +44,7 @@ function limitRecentFiles(files, maxFiles) {
 
 function HomePage() {
   const { isDarkMode, toggleTheme } = useTheme()
-  const { documentState, initializeDocument, updateDocumentContent, getPendingProposals, updateCounter, selectedAgent, setSelectedAgent, executeAgent, isExecuting, executionProgress, changeProposals, cancelExecution } = useAgents()
+  const { documentState, documentContent, initializeDocument, updateDocumentContent, getPendingProposals, selectedAgent, setSelectedAgent, executeAgent, isExecuting, executionProgress, changeProposals, cancelExecution } = useAgents()
   const [text, setText] = useState('')
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [currentDocId, setCurrentDocId] = useState(null)
@@ -215,18 +215,12 @@ function HomePage() {
     textRef.current = text
   }, [text])
 
-  // Sync text with documentState when it changes from agent actions
+  // Sync text with documentState when content changes from agent actions
   useEffect(() => {
-    if (documentState && updateCounter > 0) {
-      const stateContent = documentState.getContent()
-      // Update text when proposals are approved (updateCounter changes)
-      // Only update if content actually changed to avoid overwriting user edits
-      // Use textRef.current to get latest value without triggering infinite loop
-      if (stateContent && stateContent !== textRef.current) {
-        setText(stateContent)
-      }
+    if (documentContent && documentContent !== textRef.current) {
+      setText(documentContent)
     }
-  }, [updateCounter, documentState])
+  }, [documentContent])
 
   const saveDocument = useCallback(async () => {
     if (!text.trim()) return

--- a/src/services/agents/__tests__/documentState.proposals.test.js
+++ b/src/services/agents/__tests__/documentState.proposals.test.js
@@ -1,18 +1,28 @@
 import { describe, test, expect, beforeEach } from 'vitest'
-import { DocumentState } from '../documentState'
+import {
+  createDocumentState,
+  addChangeProposal,
+  getChangeProposals,
+  getPendingProposals,
+  approveProposal,
+  rejectProposal,
+  approveAllFromAgent,
+  applyChange,
+  exportState
+} from '../documentState'
 
-describe('DocumentState - Proposal Management', () => {
-  let docState
+describe('DocumentState - Proposal Management (Pure Functions)', () => {
+  let state
 
   beforeEach(() => {
-    docState = new DocumentState('The quick brown fox jumps over the lazy dog', {
+    state = createDocumentState('The quick brown fox jumps over the lazy dog', {
       title: 'Test Document'
     })
   })
 
   describe('addChangeProposal', () => {
     test('adds proposal with unique ID', () => {
-      const proposalId = docState.addChangeProposal({
+      const { newState, proposalId } = addChangeProposal(state, {
         type: 'replace',
         location: { start: 4, end: 9 },
         originalText: 'quick',
@@ -26,13 +36,28 @@ describe('DocumentState - Proposal Management', () => {
       expect(proposalId).toBeTruthy()
       expect(proposalId).toMatch(/^proposal-/)
 
-      const proposals = docState.getChangeProposals()
+      const proposals = getChangeProposals(newState)
       expect(proposals).toHaveLength(1)
       expect(proposals[0].id).toBe(proposalId)
     })
 
+    test('does not mutate original state', () => {
+      addChangeProposal(state, {
+        type: 'replace',
+        location: { start: 0, end: 3 },
+        originalText: 'The',
+        proposedText: 'A',
+        rationale: 'Test',
+        category: 'style',
+        priority: 'minor',
+        agentId: 'editor-agent'
+      })
+
+      expect(getChangeProposals(state)).toHaveLength(0)
+    })
+
     test('sets status to pending by default', () => {
-      const proposalId = docState.addChangeProposal({
+      const { newState } = addChangeProposal(state, {
         type: 'replace',
         location: { start: 0, end: 3 },
         originalText: 'The',
@@ -43,13 +68,13 @@ describe('DocumentState - Proposal Management', () => {
         agentId: 'editor-agent'
       })
 
-      const proposals = docState.getChangeProposals()
+      const proposals = getChangeProposals(newState)
       expect(proposals[0].status).toBe('pending')
       expect(proposals[0].createdAt).toBeInstanceOf(Date)
     })
 
     test('generates unique IDs for multiple proposals', () => {
-      const id1 = docState.addChangeProposal({
+      const { newState: state1, proposalId: id1 } = addChangeProposal(state, {
         type: 'replace',
         location: { start: 0, end: 3 },
         originalText: 'The',
@@ -60,7 +85,7 @@ describe('DocumentState - Proposal Management', () => {
         agentId: 'agent-1'
       })
 
-      const id2 = docState.addChangeProposal({
+      const { proposalId: id2 } = addChangeProposal(state1, {
         type: 'replace',
         location: { start: 4, end: 9 },
         originalText: 'quick',
@@ -76,8 +101,11 @@ describe('DocumentState - Proposal Management', () => {
   })
 
   describe('getChangeProposals', () => {
+    let stateWithProposals
+
     beforeEach(() => {
-      docState.addChangeProposal({
+      let current = state
+      current = addChangeProposal(current, {
         type: 'replace',
         agentId: 'editor-agent',
         category: 'style',
@@ -86,9 +114,9 @@ describe('DocumentState - Proposal Management', () => {
         originalText: 'The',
         proposedText: 'A',
         rationale: 'Test'
-      })
+      }).newState
 
-      docState.addChangeProposal({
+      current = addChangeProposal(current, {
         type: 'insert',
         agentId: 'revision-agent',
         category: 'content',
@@ -97,9 +125,9 @@ describe('DocumentState - Proposal Management', () => {
         originalText: '',
         proposedText: 'very ',
         rationale: 'Test'
-      })
+      }).newState
 
-      docState.addChangeProposal({
+      current = addChangeProposal(current, {
         type: 'replace',
         agentId: 'editor-agent',
         category: 'grammar',
@@ -108,40 +136,42 @@ describe('DocumentState - Proposal Management', () => {
         originalText: 'fox',
         proposedText: 'cat',
         rationale: 'Test'
-      })
+      }).newState
+
+      stateWithProposals = current
     })
 
     test('returns all proposals when no filter', () => {
-      const proposals = docState.getChangeProposals()
+      const proposals = getChangeProposals(stateWithProposals)
       expect(proposals).toHaveLength(3)
     })
 
     test('filters by status', () => {
-      const proposals = docState.getChangeProposals({ status: 'pending' })
+      const proposals = getChangeProposals(stateWithProposals, { status: 'pending' })
       expect(proposals).toHaveLength(3)
       expect(proposals.every(p => p.status === 'pending')).toBe(true)
     })
 
     test('filters by agentId', () => {
-      const proposals = docState.getChangeProposals({ agentId: 'editor-agent' })
+      const proposals = getChangeProposals(stateWithProposals, { agentId: 'editor-agent' })
       expect(proposals).toHaveLength(2)
       expect(proposals.every(p => p.agentId === 'editor-agent')).toBe(true)
     })
 
     test('filters by category', () => {
-      const proposals = docState.getChangeProposals({ category: 'style' })
+      const proposals = getChangeProposals(stateWithProposals, { category: 'style' })
       expect(proposals).toHaveLength(1)
       expect(proposals[0].category).toBe('style')
     })
 
     test('filters by priority', () => {
-      const proposals = docState.getChangeProposals({ priority: 'important' })
+      const proposals = getChangeProposals(stateWithProposals, { priority: 'important' })
       expect(proposals).toHaveLength(1)
       expect(proposals[0].priority).toBe('important')
     })
 
     test('combines multiple filters', () => {
-      const proposals = docState.getChangeProposals({
+      const proposals = getChangeProposals(stateWithProposals, {
         agentId: 'editor-agent',
         category: 'style'
       })
@@ -153,7 +183,8 @@ describe('DocumentState - Proposal Management', () => {
 
   describe('getPendingProposals', () => {
     test('returns only pending proposals', () => {
-      const id1 = docState.addChangeProposal({
+      let current = state
+      const { newState: s1 } = addChangeProposal(current, {
         type: 'replace',
         location: { start: 0, end: 3 },
         originalText: 'The',
@@ -164,7 +195,7 @@ describe('DocumentState - Proposal Management', () => {
         agentId: 'agent-1'
       })
 
-      const id2 = docState.addChangeProposal({
+      const { newState: s2, proposalId: id2 } = addChangeProposal(s1, {
         type: 'replace',
         location: { start: 4, end: 9 },
         originalText: 'quick',
@@ -175,10 +206,11 @@ describe('DocumentState - Proposal Management', () => {
         agentId: 'agent-1'
       })
 
-      // Approve one proposal
-      docState.approveProposal(id1)
+      // Approve first proposal
+      const id1 = getChangeProposals(s2)[0].id
+      const afterApprove = approveProposal(s2, id1)
 
-      const pendingProposals = docState.getPendingProposals()
+      const pendingProposals = getPendingProposals(afterApprove)
       expect(pendingProposals).toHaveLength(1)
       expect(pendingProposals[0].id).toBe(id2)
     })
@@ -186,7 +218,7 @@ describe('DocumentState - Proposal Management', () => {
 
   describe('approveProposal', () => {
     test('applies replace change using text matching', () => {
-      const proposalId = docState.addChangeProposal({
+      const { newState, proposalId } = addChangeProposal(state, {
         type: 'replace',
         location: { start: 4, end: 9 },
         originalText: 'quick',
@@ -197,14 +229,13 @@ describe('DocumentState - Proposal Management', () => {
         agentId: 'editor-agent'
       })
 
-      const newContent = docState.approveProposal(proposalId)
+      const afterApprove = approveProposal(newState, proposalId)
 
-      expect(newContent).toBe('The fast brown fox jumps over the lazy dog')
-      expect(docState.getContent()).toBe('The fast brown fox jumps over the lazy dog')
+      expect(afterApprove.content).toBe('The fast brown fox jumps over the lazy dog')
     })
 
-    test('updates proposal status to approved', () => {
-      const proposalId = docState.addChangeProposal({
+    test('does not mutate original state', () => {
+      const { newState, proposalId } = addChangeProposal(state, {
         type: 'replace',
         location: { start: 4, end: 9 },
         originalText: 'quick',
@@ -215,17 +246,32 @@ describe('DocumentState - Proposal Management', () => {
         agentId: 'editor-agent'
       })
 
-      docState.approveProposal(proposalId)
+      approveProposal(newState, proposalId)
 
-      const proposals = docState.getChangeProposals()
-      const approvedProposal = proposals.find(p => p.id === proposalId)
+      expect(newState.content).toBe('The quick brown fox jumps over the lazy dog')
+    })
+
+    test('updates proposal status to approved', () => {
+      const { newState, proposalId } = addChangeProposal(state, {
+        type: 'replace',
+        location: { start: 4, end: 9 },
+        originalText: 'quick',
+        proposedText: 'fast',
+        rationale: 'Test',
+        category: 'style',
+        priority: 'minor',
+        agentId: 'editor-agent'
+      })
+
+      const afterApprove = approveProposal(newState, proposalId)
+      const approvedProposal = getChangeProposals(afterApprove).find(p => p.id === proposalId)
 
       expect(approvedProposal.status).toBe('approved')
       expect(approvedProposal.appliedAt).toBeInstanceOf(Date)
     })
 
     test('creates version history entry with agent source', () => {
-      const proposalId = docState.addChangeProposal({
+      const { newState, proposalId } = addChangeProposal(state, {
         type: 'replace',
         location: { start: 4, end: 9 },
         originalText: 'quick',
@@ -236,18 +282,16 @@ describe('DocumentState - Proposal Management', () => {
         agentId: 'editor-agent'
       })
 
-      const versionsBefore = docState.getVersionHistory().length
-      docState.approveProposal(proposalId)
-      const versionsAfter = docState.getVersionHistory().length
+      const versionsBefore = newState.versions.length
+      const afterApprove = approveProposal(newState, proposalId)
 
-      expect(versionsAfter).toBe(versionsBefore + 1)
-
-      const latestVersion = docState.getVersionHistory()[versionsAfter - 1]
+      expect(afterApprove.versions.length).toBe(versionsBefore + 1)
+      const latestVersion = afterApprove.versions[afterApprove.versions.length - 1]
       expect(latestVersion.source).toBe('agent:editor-agent')
     })
 
     test('tracks applied changes', () => {
-      const proposalId = docState.addChangeProposal({
+      const { newState, proposalId } = addChangeProposal(state, {
         type: 'replace',
         location: { start: 0, end: 3 },
         originalText: 'The',
@@ -258,9 +302,9 @@ describe('DocumentState - Proposal Management', () => {
         agentId: 'editor-agent'
       })
 
-      docState.approveProposal(proposalId)
+      const afterApprove = approveProposal(newState, proposalId)
+      const exported = exportState(afterApprove)
 
-      const exported = docState.export()
       expect(exported.appliedChanges).toHaveLength(1)
       expect(exported.appliedChanges[0].proposalId).toBe(proposalId)
       expect(exported.appliedChanges[0].timestamp).toBeInstanceOf(Date)
@@ -268,12 +312,12 @@ describe('DocumentState - Proposal Management', () => {
 
     test('throws error when proposal not found', () => {
       expect(() => {
-        docState.approveProposal('non-existent-id')
+        approveProposal(state, 'non-existent-id')
       }).toThrow('Proposal non-existent-id not found')
     })
 
     test('throws error when proposal not pending', () => {
-      const proposalId = docState.addChangeProposal({
+      const { newState, proposalId } = addChangeProposal(state, {
         type: 'replace',
         location: { start: 0, end: 3 },
         originalText: 'The',
@@ -284,15 +328,16 @@ describe('DocumentState - Proposal Management', () => {
         agentId: 'editor-agent'
       })
 
-      docState.approveProposal(proposalId)
+      const afterApprove = approveProposal(newState, proposalId)
 
       expect(() => {
-        docState.approveProposal(proposalId)
+        approveProposal(afterApprove, proposalId)
       }).toThrow(`Proposal ${proposalId} is not pending`)
     })
 
     test('marks other pending proposals as potentially invalid', () => {
-      const id1 = docState.addChangeProposal({
+      let current = state
+      const { newState: s1, proposalId: id1 } = addChangeProposal(current, {
         type: 'replace',
         location: { start: 4, end: 9 },
         originalText: 'quick',
@@ -303,7 +348,7 @@ describe('DocumentState - Proposal Management', () => {
         agentId: 'agent-1'
       })
 
-      const id2 = docState.addChangeProposal({
+      const { newState: s2, proposalId: id2 } = addChangeProposal(s1, {
         type: 'replace',
         location: { start: 4, end: 9 },
         originalText: 'quick',
@@ -315,11 +360,9 @@ describe('DocumentState - Proposal Management', () => {
       })
 
       // Approve first proposal - should mark second as invalid
-      docState.approveProposal(id1)
+      const afterApprove = approveProposal(s2, id1)
 
-      const proposals = docState.getChangeProposals()
-      const secondProposal = proposals.find(p => p.id === id2)
-
+      const secondProposal = getChangeProposals(afterApprove).find(p => p.id === id2)
       expect(secondProposal.status).toBe('pending')
       expect(secondProposal.metadata?.mayBeInvalid).toBe(true)
     })
@@ -327,7 +370,7 @@ describe('DocumentState - Proposal Management', () => {
 
   describe('rejectProposal', () => {
     test('updates proposal status to rejected', () => {
-      const proposalId = docState.addChangeProposal({
+      const { newState, proposalId } = addChangeProposal(state, {
         type: 'replace',
         location: { start: 0, end: 3 },
         originalText: 'The',
@@ -338,17 +381,16 @@ describe('DocumentState - Proposal Management', () => {
         agentId: 'editor-agent'
       })
 
-      const proposal = docState.rejectProposal(proposalId, 'Not needed')
+      const afterReject = rejectProposal(newState, proposalId, 'Not needed')
+      const rejectedProposal = getChangeProposals(afterReject).find(p => p.id === proposalId)
 
-      expect(proposal.status).toBe('rejected')
-      expect(proposal.rejectedAt).toBeInstanceOf(Date)
-      expect(proposal.rejectionReason).toBe('Not needed')
+      expect(rejectedProposal.status).toBe('rejected')
+      expect(rejectedProposal.rejectedAt).toBeInstanceOf(Date)
+      expect(rejectedProposal.rejectionReason).toBe('Not needed')
     })
 
     test('does not change document content', () => {
-      const originalContent = docState.getContent()
-
-      const proposalId = docState.addChangeProposal({
+      const { newState, proposalId } = addChangeProposal(state, {
         type: 'replace',
         location: { start: 0, end: 3 },
         originalText: 'The',
@@ -359,19 +401,18 @@ describe('DocumentState - Proposal Management', () => {
         agentId: 'editor-agent'
       })
 
-      docState.rejectProposal(proposalId)
-
-      expect(docState.getContent()).toBe(originalContent)
+      const afterReject = rejectProposal(newState, proposalId)
+      expect(afterReject.content).toBe(state.content)
     })
 
     test('throws error when proposal not found', () => {
       expect(() => {
-        docState.rejectProposal('non-existent-id')
+        rejectProposal(state, 'non-existent-id')
       }).toThrow('Proposal non-existent-id not found')
     })
 
     test('allows rejection with empty reason', () => {
-      const proposalId = docState.addChangeProposal({
+      const { newState, proposalId } = addChangeProposal(state, {
         type: 'replace',
         location: { start: 0, end: 3 },
         originalText: 'The',
@@ -382,7 +423,8 @@ describe('DocumentState - Proposal Management', () => {
         agentId: 'editor-agent'
       })
 
-      const proposal = docState.rejectProposal(proposalId)
+      const afterReject = rejectProposal(newState, proposalId)
+      const proposal = getChangeProposals(afterReject).find(p => p.id === proposalId)
 
       expect(proposal.status).toBe('rejected')
       expect(proposal.rejectionReason).toBe('')
@@ -390,8 +432,11 @@ describe('DocumentState - Proposal Management', () => {
   })
 
   describe('approveAllFromAgent', () => {
+    let stateWithProposals
+
     beforeEach(() => {
-      docState.addChangeProposal({
+      let current = state
+      current = addChangeProposal(current, {
         type: 'replace',
         location: { start: 4, end: 9 },
         originalText: 'quick',
@@ -400,9 +445,9 @@ describe('DocumentState - Proposal Management', () => {
         category: 'style',
         priority: 'minor',
         agentId: 'editor-agent'
-      })
+      }).newState
 
-      docState.addChangeProposal({
+      current = addChangeProposal(current, {
         type: 'replace',
         location: { start: 16, end: 19 },
         originalText: 'fox',
@@ -411,9 +456,9 @@ describe('DocumentState - Proposal Management', () => {
         category: 'content',
         priority: 'minor',
         agentId: 'editor-agent'
-      })
+      }).newState
 
-      docState.addChangeProposal({
+      current = addChangeProposal(current, {
         type: 'replace',
         location: { start: 35, end: 39 },
         originalText: 'lazy',
@@ -422,182 +467,112 @@ describe('DocumentState - Proposal Management', () => {
         category: 'style',
         priority: 'minor',
         agentId: 'revision-agent'
-      })
+      }).newState
+
+      stateWithProposals = current
     })
 
     test('approves all proposals from specified agent', () => {
-      const results = docState.approveAllFromAgent('editor-agent')
+      const { newState, results } = approveAllFromAgent(stateWithProposals, 'editor-agent')
 
       expect(results).toHaveLength(2)
       expect(results.every(r => r.success)).toBe(true)
 
-      const editorProposals = docState.getChangeProposals({ agentId: 'editor-agent' })
+      const editorProposals = getChangeProposals(newState, { agentId: 'editor-agent' })
       expect(editorProposals.every(p => p.status === 'approved')).toBe(true)
     })
 
     test('does not approve proposals from other agents', () => {
-      docState.approveAllFromAgent('editor-agent')
+      const { newState } = approveAllFromAgent(stateWithProposals, 'editor-agent')
 
-      const revisionProposals = docState.getChangeProposals({ agentId: 'revision-agent' })
+      const revisionProposals = getChangeProposals(newState, { agentId: 'revision-agent' })
       expect(revisionProposals[0].status).toBe('pending')
     })
 
-    test('returns all results for multiple proposals', () => {
-      // Add multiple proposals from same agent
-      docState.addChangeProposal({
-        type: 'replace',
-        location: { start: 4, end: 9 },
-        originalText: 'quick',
-        proposedText: 'fast',
-        rationale: 'Test',
-        category: 'style',
-        priority: 'minor',
-        agentId: 'batch-agent'
-      })
-
-      docState.addChangeProposal({
-        type: 'replace',
-        location: { start: 10, end: 15 },
-        originalText: 'brown',
-        proposedText: 'red',
-        rationale: 'Test',
-        category: 'style',
-        priority: 'minor',
-        agentId: 'batch-agent'
-      })
-
-      const results = docState.approveAllFromAgent('batch-agent')
-
-      expect(results).toHaveLength(2)
-      expect(results.every(r => r.success)).toBe(true)
-      expect(results.every(r => r.proposalId)).toBeTruthy()
-    })
-
     test('handles agent with no proposals', () => {
-      const results = docState.approveAllFromAgent('non-existent-agent')
-
+      const { results } = approveAllFromAgent(stateWithProposals, 'non-existent-agent')
       expect(results).toHaveLength(0)
     })
   })
 
   describe('applyChange', () => {
+    const content = 'The quick brown fox jumps over the lazy dog'
+
     test('handles replace operation with text matching', () => {
-      const proposal = {
+      const newContent = applyChange(content, {
         type: 'replace',
         location: { start: 4, end: 9 },
         originalText: 'quick',
-        proposedText: 'fast',
-        rationale: 'Test',
-        category: 'style',
-        priority: 'minor',
-        agentId: 'editor-agent'
-      }
-
-      const newContent = docState.applyChange(proposal)
+        proposedText: 'fast'
+      })
 
       expect(newContent).toBe('The fast brown fox jumps over the lazy dog')
     })
 
     test('handles replace operation with position fallback', () => {
-      const proposal = {
+      const newContent = applyChange(content, {
         type: 'replace',
         location: { start: 4, end: 9 },
         originalText: 'NONEXISTENT',
-        proposedText: 'fast',
-        rationale: 'Test',
-        category: 'style',
-        priority: 'minor',
-        agentId: 'editor-agent'
-      }
-
-      const newContent = docState.applyChange(proposal)
+        proposedText: 'fast'
+      })
 
       // Falls back to position-based replacement
       expect(newContent).toBe('The fast brown fox jumps over the lazy dog')
     })
 
     test('handles insert operation', () => {
-      const proposal = {
+      const newContent = applyChange(content, {
         type: 'insert',
         location: { start: 10, end: 10 },
         originalText: '',
-        proposedText: 'very ',
-        rationale: 'Test',
-        category: 'style',
-        priority: 'minor',
-        agentId: 'editor-agent'
-      }
-
-      const newContent = docState.applyChange(proposal)
+        proposedText: 'very '
+      })
 
       expect(newContent).toBe('The quick very brown fox jumps over the lazy dog')
     })
 
     test('handles delete operation', () => {
-      const proposal = {
+      const newContent = applyChange(content, {
         type: 'delete',
         location: { start: 4, end: 10 },
         originalText: 'quick ',
-        proposedText: '',
-        rationale: 'Test',
-        category: 'style',
-        priority: 'minor',
-        agentId: 'editor-agent'
-      }
-
-      const newContent = docState.applyChange(proposal)
+        proposedText: ''
+      })
 
       expect(newContent).toBe('The brown fox jumps over the lazy dog')
     })
 
     test('handles restructure operation', () => {
-      const proposal = {
+      const newContent = applyChange(content, {
         type: 'restructure',
         location: { start: 0, end: 44 },
-        originalText: 'The quick brown fox jumps over the lazy dog',
-        proposedText: 'A lazy dog was jumped over by a quick brown fox',
-        rationale: 'Test',
-        category: 'structure',
-        priority: 'major',
-        agentId: 'editor-agent'
-      }
-
-      const newContent = docState.applyChange(proposal)
+        originalText: content,
+        proposedText: 'A lazy dog was jumped over by a quick brown fox'
+      })
 
       expect(newContent).toBe('A lazy dog was jumped over by a quick brown fox')
     })
 
     test('handles comment operation without changing content', () => {
-      const proposal = {
+      const newContent = applyChange(content, {
         type: 'comment',
         location: { start: 0, end: 0 },
         originalText: '',
-        proposedText: 'This is a comment',
-        rationale: 'Test',
-        category: 'comment',
-        priority: 'minor',
-        agentId: 'editor-agent'
-      }
+        proposedText: 'This is a comment'
+      })
 
-      const newContent = docState.applyChange(proposal)
-
-      expect(newContent).toBe('The quick brown fox jumps over the lazy dog')
+      expect(newContent).toBe(content)
     })
 
     test('throws error on unknown change type', () => {
-      const proposal = {
-        type: 'unknown',
-        location: { start: 0, end: 0 },
-        originalText: '',
-        proposedText: 'test',
-        rationale: 'Test',
-        category: 'test',
-        priority: 'minor',
-        agentId: 'editor-agent'
-      }
-
       expect(() => {
-        docState.applyChange(proposal)
+        applyChange(content, {
+          type: 'unknown',
+          location: { start: 0, end: 0 },
+          originalText: '',
+          proposedText: 'test'
+        })
       }).toThrow('Unknown change type: unknown')
     })
   })

--- a/src/services/agents/__tests__/documentState.test.js
+++ b/src/services/agents/__tests__/documentState.test.js
@@ -1,173 +1,184 @@
 import { describe, test, expect, beforeEach } from 'vitest'
-import { DocumentState } from '../documentState'
+import {
+  createDocumentState,
+  updateContent,
+  addChangeProposal,
+  addAnnotation,
+  getChangeProposals,
+  getAnnotations,
+  revertToVersion,
+  exportState,
+  importState,
+  countWords,
+  computeDiff
+} from '../documentState'
 
-describe('DocumentState - Core Functionality', () => {
-  describe('Constructor', () => {
+describe('DocumentState - Core Functionality (Pure Functions)', () => {
+  describe('createDocumentState', () => {
     test('initializes with content and metadata', () => {
-      const content = 'Hello world'
-      const metadata = {
+      const state = createDocumentState('Hello world', {
         title: 'My Document',
         createdAt: new Date('2024-01-01')
-      }
+      })
 
-      const docState = new DocumentState(content, metadata)
-
-      expect(docState.getContent()).toBe('Hello world')
-      expect(docState.getMetadata().title).toBe('My Document')
-      expect(docState.getMetadata().createdAt).toEqual(new Date('2024-01-01'))
-      expect(docState.getMetadata().wordCount).toBe(2)
+      expect(state.content).toBe('Hello world')
+      expect(state.metadata.title).toBe('My Document')
+      expect(state.metadata.createdAt).toEqual(new Date('2024-01-01'))
+      expect(state.metadata.wordCount).toBe(2)
     })
 
     test('initializes with empty content', () => {
-      const docState = new DocumentState()
+      const state = createDocumentState()
 
-      expect(docState.getContent()).toBe('')
-      expect(docState.getMetadata().title).toBe('Untitled Document')
-      expect(docState.getMetadata().wordCount).toBe(0)
+      expect(state.content).toBe('')
+      expect(state.metadata.title).toBe('Untitled Document')
+      expect(state.metadata.wordCount).toBe(0)
     })
 
     test('creates initial version in history', () => {
-      const docState = new DocumentState('Initial content')
+      const state = createDocumentState('Initial content')
 
-      const versions = docState.getVersionHistory()
-      expect(versions).toHaveLength(1)
-      expect(versions[0].content).toBe('Initial content')
-      expect(versions[0].source).toBe('initial')
-      expect(versions[0].timestamp).toBeInstanceOf(Date)
+      expect(state.versions).toHaveLength(1)
+      expect(state.versions[0].content).toBe('Initial content')
+      expect(state.versions[0].source).toBe('initial')
+      expect(state.versions[0].timestamp).toBeInstanceOf(Date)
     })
   })
 
-  describe('getContent and getMetadata', () => {
-    let docState
+  describe('state access', () => {
+    let state
 
     beforeEach(() => {
-      docState = new DocumentState('Test content', {
+      state = createDocumentState('Test content', {
         title: 'Test Doc',
         author: 'Test Author'
       })
     })
 
-    test('getContent returns current content', () => {
-      expect(docState.getContent()).toBe('Test content')
+    test('content is accessible directly', () => {
+      expect(state.content).toBe('Test content')
     })
 
-    test('getMetadata returns copy of metadata', () => {
-      const metadata = docState.getMetadata()
-
-      expect(metadata.title).toBe('Test Doc')
-      expect(metadata.author).toBe('Test Author')
-      expect(metadata.wordCount).toBe(2)
-
-      // Ensure it's a copy, not reference
-      metadata.title = 'Modified'
-      expect(docState.getMetadata().title).toBe('Test Doc')
+    test('metadata is accessible directly', () => {
+      expect(state.metadata.title).toBe('Test Doc')
+      expect(state.metadata.author).toBe('Test Author')
+      expect(state.metadata.wordCount).toBe(2)
     })
   })
 
   describe('updateContent', () => {
-    let docState
+    let state
 
     beforeEach(() => {
-      docState = new DocumentState('Original content')
+      state = createDocumentState('Original content')
     })
 
-    test('updates content and creates version history entry', () => {
-      const versionId = docState.updateContent('New content')
+    test('returns new state with updated content and version', () => {
+      const newState = updateContent(state, 'New content')
 
-      expect(docState.getContent()).toBe('New content')
-      expect(versionId).toBe(1) // Second version (0-indexed)
+      expect(newState.content).toBe('New content')
+      expect(newState.versions).toHaveLength(2)
+      expect(newState.versions[1].content).toBe('New content')
+      expect(newState.versions[1].source).toBe('user')
+    })
 
-      const versions = docState.getVersionHistory()
-      expect(versions).toHaveLength(2)
-      expect(versions[1].content).toBe('New content')
-      expect(versions[1].source).toBe('user')
+    test('does not mutate original state', () => {
+      updateContent(state, 'New content')
+
+      expect(state.content).toBe('Original content')
+      expect(state.versions).toHaveLength(1)
     })
 
     test('updates word count in metadata', () => {
-      docState.updateContent('This has five words here')
+      const newState = updateContent(state, 'This has five words here')
 
-      expect(docState.getMetadata().wordCount).toBe(5)
+      expect(newState.metadata.wordCount).toBe(5)
     })
 
     test('updates updatedAt timestamp', () => {
       const beforeUpdate = new Date()
-      docState.updateContent('Updated content')
+      const newState = updateContent(state, 'Updated content')
       const afterUpdate = new Date()
 
-      const updatedAt = docState.getMetadata().updatedAt
+      const updatedAt = newState.metadata.updatedAt
       expect(updatedAt.getTime()).toBeGreaterThanOrEqual(beforeUpdate.getTime())
       expect(updatedAt.getTime()).toBeLessThanOrEqual(afterUpdate.getTime())
     })
 
     test('allows custom source for version history', () => {
-      docState.updateContent('Agent content', 'agent:brainstorm')
+      const newState = updateContent(state, 'Agent content', 'agent:brainstorm')
 
-      const versions = docState.getVersionHistory()
-      expect(versions[1].source).toBe('agent:brainstorm')
+      expect(newState.versions[1].source).toBe('agent:brainstorm')
     })
 
     test('handles rapid updates', () => {
-      docState.updateContent('Update 1')
-      docState.updateContent('Update 2')
-      docState.updateContent('Update 3')
+      let current = state
+      current = updateContent(current, 'Update 1')
+      current = updateContent(current, 'Update 2')
+      current = updateContent(current, 'Update 3')
 
-      expect(docState.getContent()).toBe('Update 3')
-      const versions = docState.getVersionHistory()
-      expect(versions).toHaveLength(4) // Initial + 3 updates
+      expect(current.content).toBe('Update 3')
+      expect(current.versions).toHaveLength(4) // Initial + 3 updates
     })
 
     test('includes diff in version history', () => {
-      docState.updateContent('This is much longer content')
+      const newState = updateContent(state, 'This is much longer content')
 
-      const versions = docState.getVersionHistory()
-      expect(versions[1].diff).toBeDefined()
-      expect(versions[1].diff.type).toBe('addition')
+      expect(newState.versions[1].diff).toBeDefined()
+      expect(newState.versions[1].diff.type).toBe('addition')
+    })
+
+    test('caps version history at 50 entries', () => {
+      let current = state
+      for (let i = 0; i < 55; i++) {
+        current = updateContent(current, `Version ${i}`)
+      }
+
+      expect(current.versions.length).toBeLessThanOrEqual(50)
+      // Initial version is preserved
+      expect(current.versions[0].source).toBe('initial')
+      // Latest version is present
+      expect(current.content).toBe('Version 54')
     })
   })
 
   describe('countWords', () => {
-    let docState
-
-    beforeEach(() => {
-      docState = new DocumentState('')
-    })
-
     test('counts words accurately', () => {
-      expect(docState.countWords('Hello world')).toBe(2)
-      expect(docState.countWords('One two three four five')).toBe(5)
+      expect(countWords('Hello world')).toBe(2)
+      expect(countWords('One two three four five')).toBe(5)
     })
 
     test('handles empty string', () => {
-      expect(docState.countWords('')).toBe(0)
+      expect(countWords('')).toBe(0)
     })
 
     test('handles whitespace', () => {
-      expect(docState.countWords('   ')).toBe(0)
-      expect(docState.countWords('  word  ')).toBe(1)
-      expect(docState.countWords('word1   word2')).toBe(2)
+      expect(countWords('   ')).toBe(0)
+      expect(countWords('  word  ')).toBe(1)
+      expect(countWords('word1   word2')).toBe(2)
     })
 
     test('handles special characters', () => {
-      expect(docState.countWords('hello, world!')).toBe(2)
-      expect(docState.countWords('one-two three')).toBe(2)
+      expect(countWords('hello, world!')).toBe(2)
+      expect(countWords('one-two three')).toBe(2)
     })
 
     test('handles newlines and tabs', () => {
-      expect(docState.countWords('line1\nline2')).toBe(2)
-      expect(docState.countWords('tab\there')).toBe(2)
+      expect(countWords('line1\nline2')).toBe(2)
+      expect(countWords('tab\there')).toBe(2)
     })
   })
 
-  describe('export and import', () => {
-    let docState
+  describe('exportState and importState', () => {
+    let state
 
     beforeEach(() => {
-      docState = new DocumentState('Export test content', {
+      state = createDocumentState('Export test content', {
         title: 'Export Test',
         author: 'Tester'
       })
-      docState.updateContent('Updated content')
-      docState.addChangeProposal({
+      state = updateContent(state, 'Updated content')
+      const result = addChangeProposal(state, {
         type: 'replace',
         location: { start: 0, end: 7 },
         originalText: 'Updated',
@@ -177,15 +188,17 @@ describe('DocumentState - Core Functionality', () => {
         priority: 'minor',
         agentId: 'test-agent'
       })
-      docState.addAnnotation({
+      state = result.newState
+      const annotationResult = addAnnotation(state, {
         agentId: 'test-agent',
         category: 'analysis',
         text: 'Test annotation'
       })
+      state = annotationResult.newState
     })
 
     test('export serializes state correctly', () => {
-      const exported = docState.export()
+      const exported = exportState(state)
 
       expect(exported.content).toBe('Updated content')
       expect(exported.metadata.title).toBe('Export Test')
@@ -197,14 +210,14 @@ describe('DocumentState - Core Functionality', () => {
     })
 
     test('import deserializes state correctly', () => {
-      const exported = docState.export()
-      const imported = DocumentState.import(exported)
+      const exported = exportState(state)
+      const imported = importState(exported)
 
-      expect(imported.getContent()).toBe('Updated content')
-      expect(imported.getMetadata().title).toBe('Export Test')
-      expect(imported.getVersionHistory()).toHaveLength(2)
-      expect(imported.getChangeProposals()).toHaveLength(1)
-      expect(imported.getAnnotations()).toHaveLength(1)
+      expect(imported.content).toBe('Updated content')
+      expect(imported.metadata.title).toBe('Export Test')
+      expect(imported.versions).toHaveLength(2)
+      expect(imported.changeProposals).toHaveLength(1)
+      expect(imported.annotations).toHaveLength(1)
     })
 
     test('import handles missing optional fields', () => {
@@ -213,81 +226,73 @@ describe('DocumentState - Core Functionality', () => {
         metadata: { title: 'Minimal' }
       }
 
-      const imported = DocumentState.import(minimalData)
+      const imported = importState(minimalData)
 
-      expect(imported.getContent()).toBe('Minimal content')
-      expect(imported.getVersionHistory()).toEqual([])
-      expect(imported.getChangeProposals()).toEqual([])
-      expect(imported.getAnnotations()).toEqual([])
+      expect(imported.content).toBe('Minimal content')
+      expect(imported.versions).toEqual([])
+      expect(imported.changeProposals).toEqual([])
+      expect(imported.annotations).toEqual([])
     })
 
     test('export-import roundtrip preserves all data', () => {
-      const exported = docState.export()
-      const imported = DocumentState.import(exported)
-      const reExported = imported.export()
+      const exported = exportState(state)
+      const imported = importState(exported)
+      const reExported = exportState(imported)
 
       expect(reExported).toEqual(exported)
     })
   })
 
   describe('Version History', () => {
-    let docState
+    let state
 
     beforeEach(() => {
-      docState = new DocumentState('Version 1')
+      state = createDocumentState('Version 1')
     })
 
-    test('getVersionHistory returns all versions', () => {
-      docState.updateContent('Version 2')
-      docState.updateContent('Version 3')
+    test('versions track all updates', () => {
+      let current = state
+      current = updateContent(current, 'Version 2')
+      current = updateContent(current, 'Version 3')
 
-      const versions = docState.getVersionHistory()
-      expect(versions).toHaveLength(3)
-      expect(versions[0].content).toBe('Version 1')
-      expect(versions[1].content).toBe('Version 2')
-      expect(versions[2].content).toBe('Version 3')
-    })
-
-    test('getVersionHistory returns copy of versions array', () => {
-      const versions1 = docState.getVersionHistory()
-      const versions2 = docState.getVersionHistory()
-
-      expect(versions1).toEqual(versions2)
-      expect(versions1).not.toBe(versions2) // Different array instances
+      expect(current.versions).toHaveLength(3)
+      expect(current.versions[0].content).toBe('Version 1')
+      expect(current.versions[1].content).toBe('Version 2')
+      expect(current.versions[2].content).toBe('Version 3')
     })
 
     test('revertToVersion restores previous content', () => {
-      docState.updateContent('Version 2')
-      docState.updateContent('Version 3')
+      let current = state
+      current = updateContent(current, 'Version 2')
+      current = updateContent(current, 'Version 3')
 
-      docState.revertToVersion(0)
+      current = revertToVersion(current, 0)
 
-      expect(docState.getContent()).toBe('Version 1')
-      const versions = docState.getVersionHistory()
-      expect(versions).toHaveLength(4) // Original 3 + revert creates new version
-      expect(versions[3].source).toBe('revert')
+      expect(current.content).toBe('Version 1')
+      expect(current.versions).toHaveLength(4) // Original 3 + revert creates new version
+      expect(current.versions[3].source).toBe('revert')
     })
 
     test('revertToVersion throws on invalid index', () => {
       expect(() => {
-        docState.revertToVersion(-1)
+        revertToVersion(state, -1)
       }).toThrow('Invalid version index')
 
       expect(() => {
-        docState.revertToVersion(10)
+        revertToVersion(state, 10)
       }).toThrow('Invalid version index')
     })
   })
 
   describe('Annotations', () => {
-    let docState
+    let state
 
     beforeEach(() => {
-      docState = new DocumentState('Test content')
+      state = createDocumentState('Test content')
     })
 
     test('addAnnotation creates annotation with ID', () => {
-      const annotationId = docState.addAnnotation({
+      const { newState, annotationId } = addAnnotation(state, {
         agentId: 'test-agent',
         category: 'analysis',
         text: 'This is a test annotation',
@@ -297,38 +302,51 @@ describe('DocumentState - Core Functionality', () => {
       expect(annotationId).toBeTruthy()
       expect(annotationId).toMatch(/^annotation-/)
 
-      const annotations = docState.getAnnotations()
+      const annotations = getAnnotations(newState)
       expect(annotations).toHaveLength(1)
       expect(annotations[0].id).toBe(annotationId)
       expect(annotations[0].text).toBe('This is a test annotation')
       expect(annotations[0].createdAt).toBeInstanceOf(Date)
     })
 
-    test('getAnnotations filters by agentId', () => {
-      docState.addAnnotation({ agentId: 'agent-1', category: 'analysis', text: 'A1' })
-      docState.addAnnotation({ agentId: 'agent-2', category: 'analysis', text: 'A2' })
-      docState.addAnnotation({ agentId: 'agent-1', category: 'comment', text: 'A3' })
+    test('does not mutate original state', () => {
+      addAnnotation(state, {
+        agentId: 'test-agent',
+        category: 'analysis',
+        text: 'Annotation'
+      })
 
-      const agent1Annotations = docState.getAnnotations({ agentId: 'agent-1' })
+      expect(getAnnotations(state)).toHaveLength(0)
+    })
+
+    test('getAnnotations filters by agentId', () => {
+      let current = state
+      current = addAnnotation(current, { agentId: 'agent-1', category: 'analysis', text: 'A1' }).newState
+      current = addAnnotation(current, { agentId: 'agent-2', category: 'analysis', text: 'A2' }).newState
+      current = addAnnotation(current, { agentId: 'agent-1', category: 'comment', text: 'A3' }).newState
+
+      const agent1Annotations = getAnnotations(current, { agentId: 'agent-1' })
       expect(agent1Annotations).toHaveLength(2)
       expect(agent1Annotations.every(a => a.agentId === 'agent-1')).toBe(true)
     })
 
     test('getAnnotations filters by category', () => {
-      docState.addAnnotation({ agentId: 'agent-1', category: 'analysis', text: 'A1' })
-      docState.addAnnotation({ agentId: 'agent-2', category: 'comment', text: 'A2' })
-      docState.addAnnotation({ agentId: 'agent-1', category: 'analysis', text: 'A3' })
+      let current = state
+      current = addAnnotation(current, { agentId: 'agent-1', category: 'analysis', text: 'A1' }).newState
+      current = addAnnotation(current, { agentId: 'agent-2', category: 'comment', text: 'A2' }).newState
+      current = addAnnotation(current, { agentId: 'agent-1', category: 'analysis', text: 'A3' }).newState
 
-      const analysisAnnotations = docState.getAnnotations({ category: 'analysis' })
+      const analysisAnnotations = getAnnotations(current, { category: 'analysis' })
       expect(analysisAnnotations).toHaveLength(2)
       expect(analysisAnnotations.every(a => a.category === 'analysis')).toBe(true)
     })
 
     test('getAnnotations returns all without filter', () => {
-      docState.addAnnotation({ agentId: 'agent-1', category: 'analysis', text: 'A1' })
-      docState.addAnnotation({ agentId: 'agent-2', category: 'comment', text: 'A2' })
+      let current = state
+      current = addAnnotation(current, { agentId: 'agent-1', category: 'analysis', text: 'A1' }).newState
+      current = addAnnotation(current, { agentId: 'agent-2', category: 'comment', text: 'A2' }).newState
 
-      const allAnnotations = docState.getAnnotations()
+      const allAnnotations = getAnnotations(current)
       expect(allAnnotations).toHaveLength(2)
     })
   })

--- a/src/services/agents/documentState.js
+++ b/src/services/agents/documentState.js
@@ -1,375 +1,419 @@
 /**
- * Document State Manager
+ * Document State — Immutable Data Pattern
  *
+ * Plain state objects + pure functions that return new state.
  * Maintains single source of truth for document content and metadata.
- * Tracks changes, versions, and agent interactions.
+ *
+ * The DocumentState class at the bottom is a backward-compatible wrapper
+ * for consumers that haven't migrated to the pure function API yet.
  */
 
-export class DocumentState {
-  constructor(initialContent = '', metadata = {}) {
-    this.content = initialContent
-    this.metadata = {
+const MAX_VERSIONS = 50
+
+// ─── Utilities ───────────────────────────────────────────────────────────────
+
+export function countWords(text) {
+  return text.trim().split(/\s+/).filter(w => w.length > 0).length
+}
+
+export function computeDiff(oldText, newText) {
+  return {
+    added: newText.length - oldText.length,
+    type: newText.length > oldText.length ? 'addition' : 'deletion'
+  }
+}
+
+// ─── Factory ─────────────────────────────────────────────────────────────────
+
+export function createDocumentState(content = '', metadata = {}) {
+  return {
+    content,
+    metadata: {
       title: metadata.title || 'Untitled Document',
       createdAt: metadata.createdAt || new Date(),
       updatedAt: new Date(),
-      wordCount: this.countWords(initialContent),
+      wordCount: countWords(content),
       ...metadata
-    }
-    this.versions = [{
-      content: initialContent,
+    },
+    versions: [{
+      content,
       timestamp: new Date(),
       source: 'initial'
-    }]
-    this.changeProposals = []
-    this.appliedChanges = []
-    this.annotations = [] // Agent comments and analysis
+    }],
+    changeProposals: [],
+    appliedChanges: [],
+    annotations: []
+  }
+}
+
+// ─── Pure State Transitions ──────────────────────────────────────────────────
+
+function capVersions(versions) {
+  if (versions.length <= MAX_VERSIONS) return versions
+  // Keep the initial version (index 0) and the most recent entries
+  return [versions[0], ...versions.slice(versions.length - (MAX_VERSIONS - 1))]
+}
+
+export function updateContent(state, newContent, source = 'user') {
+  const newVersions = capVersions([...state.versions, {
+    content: newContent,
+    timestamp: new Date(),
+    source,
+    diff: computeDiff(state.content, newContent)
+  }])
+
+  return {
+    ...state,
+    content: newContent,
+    metadata: {
+      ...state.metadata,
+      updatedAt: new Date(),
+      wordCount: countWords(newContent)
+    },
+    versions: newVersions
+  }
+}
+
+export function addChangeProposal(state, proposal) {
+  const proposalWithId = {
+    ...proposal,
+    id: `proposal-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+    status: 'pending',
+    createdAt: new Date()
   }
 
-  /**
-   * Get current content
-   */
-  getContent() {
-    return this.content
+  return {
+    newState: {
+      ...state,
+      changeProposals: [...state.changeProposals, proposalWithId]
+    },
+    proposalId: proposalWithId.id
   }
+}
 
-  /**
-   * Get metadata
-   */
-  getMetadata() {
-    return { ...this.metadata }
-  }
+export function applyChange(content, proposal) {
+  const { type, location, originalText, proposedText } = proposal
 
-  /**
-   * Update content and create version
-   */
-  updateContent(newContent, source = 'user') {
-    const oldContent = this.content
-    this.content = newContent
-    this.metadata.updatedAt = new Date()
-    this.metadata.wordCount = this.countWords(newContent)
-
-    // Create version history entry
-    this.versions.push({
-      content: newContent,
-      timestamp: new Date(),
-      source,
-      diff: this.computeDiff(oldContent, newContent)
-    })
-
-    return this.versions.length - 1 // Return version ID
-  }
-
-  /**
-   * Add a change proposal from an agent
-   */
-  addChangeProposal(proposal) {
-    const proposalWithId = {
-      ...proposal,
-      id: `proposal-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-      status: 'pending',
-      createdAt: new Date()
-    }
-
-    this.changeProposals.push(proposalWithId)
-    return proposalWithId.id
-  }
-
-  /**
-   * Get all change proposals
-   */
-  getChangeProposals(filter = {}) {
-    let proposals = [...this.changeProposals]
-
-    if (filter.status) {
-      proposals = proposals.filter(p => p.status === filter.status)
-    }
-
-    if (filter.agentId) {
-      proposals = proposals.filter(p => p.agentId === filter.agentId)
-    }
-
-    if (filter.category) {
-      proposals = proposals.filter(p => p.category === filter.category)
-    }
-
-    if (filter.priority) {
-      proposals = proposals.filter(p => p.priority === filter.priority)
-    }
-
-    return proposals
-  }
-
-  /**
-   * Get pending change proposals
-   */
-  getPendingProposals() {
-    return this.getChangeProposals({ status: 'pending' })
-  }
-
-  /**
-   * Approve a change proposal and apply it
-   */
-  approveProposal(proposalId) {
-    const proposal = this.changeProposals.find(p => p.id === proposalId)
-    if (!proposal) {
-      throw new Error(`Proposal ${proposalId} not found`)
-    }
-
-    if (proposal.status !== 'pending') {
-      throw new Error(`Proposal ${proposalId} is not pending`)
-    }
-
-    // Store original content to calculate actual change position
-    const contentBefore = this.content
-
-    // Apply the change
-    const newContent = this.applyChange(proposal)
-    this.updateContent(newContent, `agent:${proposal.agentId}`)
-
-    // Update proposal status
-    proposal.status = 'approved'
-    proposal.appliedAt = new Date()
-
-    // Update all pending proposals to remove the changed text from their originalText
-    // This prevents the same text from being matched multiple times
-    this.updatePendingProposalsAfterChange(contentBefore, newContent, proposal)
-
-    // Track applied change
-    this.appliedChanges.push({
-      proposalId,
-      timestamp: new Date()
-    })
-
-    return newContent
-  }
-
-  /**
-   * Reject a change proposal
-   */
-  rejectProposal(proposalId, reason = '') {
-    const proposal = this.changeProposals.find(p => p.id === proposalId)
-    if (!proposal) {
-      throw new Error(`Proposal ${proposalId} not found`)
-    }
-
-    proposal.status = 'rejected'
-    proposal.rejectedAt = new Date()
-    proposal.rejectionReason = reason
-
-    return proposal
-  }
-
-  /**
-   * Approve all proposals from an agent run
-   */
-  approveAllFromAgent(agentId) {
-    const proposals = this.getChangeProposals({
-      agentId,
-      status: 'pending'
-    })
-
-    const results = []
-    for (const proposal of proposals) {
-      try {
-        this.approveProposal(proposal.id)
-        results.push({ proposalId: proposal.id, success: true })
-      } catch (error) {
-        results.push({
-          proposalId: proposal.id,
-          success: false,
-          error: error.message
-        })
-      }
-    }
-
-    return results
-  }
-
-  /**
-   * Apply a change to the document content
-   */
-  applyChange(proposal) {
-    const { type, location, originalText, proposedText } = proposal
-    const content = this.content
-
-    switch (type) {
-      case 'replace':
-        // For replace operations, use text matching if originalText is provided
-        // This is more reliable than AI-provided character positions
-        if (originalText && originalText.trim()) {
-          // Find the text in the document
-          const index = content.indexOf(originalText)
-          if (index !== -1) {
-            // Found exact match - use it instead of positions
-            return (
-              content.substring(0, index) +
-              proposedText +
-              content.substring(index + originalText.length)
-            )
-          } else {
-            // Fallback to position-based if exact match not found
-            console.warn('Could not find exact match for originalText, using positions:', originalText.substring(0, 50))
-            return (
-              content.substring(0, location.start) +
-              proposedText +
-              content.substring(location.end)
-            )
-          }
+  switch (type) {
+    case 'replace':
+      if (originalText && originalText.trim()) {
+        const index = content.indexOf(originalText)
+        if (index !== -1) {
+          return (
+            content.substring(0, index) +
+            proposedText +
+            content.substring(index + originalText.length)
+          )
         } else {
-          // No originalText provided, use position-based replacement
+          console.warn('Could not find exact match for originalText, using positions:', originalText.substring(0, 50))
           return (
             content.substring(0, location.start) +
             proposedText +
             content.substring(location.end)
           )
         }
-
-      case 'insert':
-        // Insert text at location
+      } else {
         return (
           content.substring(0, location.start) +
           proposedText +
-          content.substring(location.start)
-        )
-
-      case 'delete':
-        // Delete text at location
-        return (
-          content.substring(0, location.start) +
           content.substring(location.end)
         )
-
-      case 'restructure':
-        // More complex restructuring
-        return proposedText // Assumes proposedText is full restructured content
-
-      case 'comment':
-        // Comments don't change content
-        return content
-
-      default:
-        throw new Error(`Unknown change type: ${type}`)
-    }
-  }
-
-  /**
-   * Add annotation (agent comment or analysis)
-   */
-  addAnnotation(annotation) {
-    const annotationWithId = {
-      ...annotation,
-      id: `annotation-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-      createdAt: new Date()
-    }
-
-    this.annotations.push(annotationWithId)
-    return annotationWithId.id
-  }
-
-  /**
-   * Get annotations
-   */
-  getAnnotations(filter = {}) {
-    let annotations = [...this.annotations]
-
-    if (filter.agentId) {
-      annotations = annotations.filter(a => a.agentId === filter.agentId)
-    }
-
-    if (filter.category) {
-      annotations = annotations.filter(a => a.category === filter.category)
-    }
-
-    return annotations
-  }
-
-  /**
-   * Get version history
-   */
-  getVersionHistory() {
-    return [...this.versions]
-  }
-
-  /**
-   * Revert to a previous version
-   */
-  revertToVersion(versionIndex) {
-    if (versionIndex < 0 || versionIndex >= this.versions.length) {
-      throw new Error(`Invalid version index: ${versionIndex}`)
-    }
-
-    const version = this.versions[versionIndex]
-    this.updateContent(version.content, 'revert')
-
-    return this.content
-  }
-
-  /**
-   * Update pending proposals after a change is applied
-   * Since we use text matching, we need to ensure pending proposals
-   * still match the updated document
-   */
-  updatePendingProposalsAfterChange(contentBefore, contentAfter, appliedProposal) {
-    const { originalText, proposedText } = appliedProposal
-
-    // For each pending proposal, check if its originalText still exists in the new content
-    this.changeProposals.forEach(proposal => {
-      if (proposal.status === 'pending' && proposal.originalText) {
-        // Check if the original text is still in the document
-        const stillExists = contentAfter.indexOf(proposal.originalText) !== -1
-
-        if (!stillExists) {
-          // The text this proposal refers to has been modified or removed
-          // Mark it with a warning but keep it pending
-          proposal.metadata = proposal.metadata || {}
-          proposal.metadata.mayBeInvalid = true
-          console.warn(`Proposal ${proposal.id} may be invalid - originalText no longer found in document`)
-        }
       }
-    })
+
+    case 'insert':
+      return (
+        content.substring(0, location.start) +
+        proposedText +
+        content.substring(location.start)
+      )
+
+    case 'delete':
+      return (
+        content.substring(0, location.start) +
+        content.substring(location.end)
+      )
+
+    case 'restructure':
+      return proposedText
+
+    case 'comment':
+      return content
+
+    default:
+      throw new Error(`Unknown change type: ${type}`)
+  }
+}
+
+function markInvalidatedProposals(proposals, contentAfter, appliedProposalId) {
+  return proposals.map(proposal => {
+    if (proposal.id === appliedProposalId) return proposal
+    if (proposal.status !== 'pending' || !proposal.originalText) return proposal
+
+    const stillExists = contentAfter.indexOf(proposal.originalText) !== -1
+    if (stillExists) return proposal
+
+    return {
+      ...proposal,
+      metadata: {
+        ...proposal.metadata,
+        mayBeInvalid: true
+      }
+    }
+  })
+}
+
+export function approveProposal(state, proposalId) {
+  const proposal = state.changeProposals.find(p => p.id === proposalId)
+  if (!proposal) {
+    throw new Error(`Proposal ${proposalId} not found`)
+  }
+  if (proposal.status !== 'pending') {
+    throw new Error(`Proposal ${proposalId} is not pending`)
   }
 
-  /**
-   * Count words in text
-   */
+  const newContent = applyChange(state.content, proposal)
+  const contentUpdated = updateContent(state, newContent, `agent:${proposal.agentId}`)
+
+  const updatedProposals = markInvalidatedProposals(
+    contentUpdated.changeProposals,
+    newContent,
+    proposalId
+  ).map(p =>
+    p.id === proposalId
+      ? { ...p, status: 'approved', appliedAt: new Date() }
+      : p
+  )
+
+  return {
+    ...contentUpdated,
+    changeProposals: updatedProposals,
+    appliedChanges: [...contentUpdated.appliedChanges, {
+      proposalId,
+      timestamp: new Date()
+    }]
+  }
+}
+
+export function rejectProposal(state, proposalId, reason = '') {
+  const proposal = state.changeProposals.find(p => p.id === proposalId)
+  if (!proposal) {
+    throw new Error(`Proposal ${proposalId} not found`)
+  }
+
+  return {
+    ...state,
+    changeProposals: state.changeProposals.map(p =>
+      p.id === proposalId
+        ? { ...p, status: 'rejected', rejectedAt: new Date(), rejectionReason: reason }
+        : p
+    )
+  }
+}
+
+export function approveAllFromAgent(state, agentId) {
+  const pending = getChangeProposals(state, { agentId, status: 'pending' })
+
+  let currentState = state
+  const results = []
+
+  for (const proposal of pending) {
+    try {
+      currentState = approveProposal(currentState, proposal.id)
+      results.push({ proposalId: proposal.id, success: true })
+    } catch (error) {
+      results.push({ proposalId: proposal.id, success: false, error: error.message })
+    }
+  }
+
+  return { newState: currentState, results }
+}
+
+export function addAnnotation(state, annotation) {
+  const annotationWithId = {
+    ...annotation,
+    id: `annotation-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+    createdAt: new Date()
+  }
+
+  return {
+    newState: {
+      ...state,
+      annotations: [...state.annotations, annotationWithId]
+    },
+    annotationId: annotationWithId.id
+  }
+}
+
+export function revertToVersion(state, versionIndex) {
+  if (versionIndex < 0 || versionIndex >= state.versions.length) {
+    throw new Error(`Invalid version index: ${versionIndex}`)
+  }
+
+  const version = state.versions[versionIndex]
+  return updateContent(state, version.content, 'revert')
+}
+
+// ─── Pure Queries ────────────────────────────────────────────────────────────
+
+export function getChangeProposals(state, filter = {}) {
+  let proposals = state.changeProposals
+
+  if (filter.status) {
+    proposals = proposals.filter(p => p.status === filter.status)
+  }
+  if (filter.agentId) {
+    proposals = proposals.filter(p => p.agentId === filter.agentId)
+  }
+  if (filter.category) {
+    proposals = proposals.filter(p => p.category === filter.category)
+  }
+  if (filter.priority) {
+    proposals = proposals.filter(p => p.priority === filter.priority)
+  }
+
+  return proposals
+}
+
+export function getPendingProposals(state) {
+  return getChangeProposals(state, { status: 'pending' })
+}
+
+export function getAnnotations(state, filter = {}) {
+  let annotations = state.annotations
+
+  if (filter.agentId) {
+    annotations = annotations.filter(a => a.agentId === filter.agentId)
+  }
+  if (filter.category) {
+    annotations = annotations.filter(a => a.category === filter.category)
+  }
+
+  return annotations
+}
+
+// ─── Export / Import ─────────────────────────────────────────────────────────
+
+export function exportState(state) {
+  return {
+    content: state.content,
+    metadata: state.metadata,
+    versions: state.versions,
+    changeProposals: state.changeProposals,
+    appliedChanges: state.appliedChanges,
+    annotations: state.annotations
+  }
+}
+
+export function importState(data) {
+  return {
+    content: data.content,
+    metadata: data.metadata,
+    versions: data.versions || [],
+    changeProposals: data.changeProposals || [],
+    appliedChanges: data.appliedChanges || [],
+    annotations: data.annotations || []
+  }
+}
+
+// ─── Backward-Compatible Class Wrapper ───────────────────────────────────────
+// Delegates to pure functions above. Consumers should migrate to the pure
+// function API (Phase 2.2–2.3), after which this class can be removed.
+
+export class DocumentState {
+  constructor(initialContent = '', metadata = {}) {
+    this._state = createDocumentState(initialContent, metadata)
+  }
+
+  getContent() {
+    return this._state.content
+  }
+
+  getMetadata() {
+    return { ...this._state.metadata }
+  }
+
+  updateContent(newContent, source = 'user') {
+    this._state = updateContent(this._state, newContent, source)
+    return this._state.versions.length - 1
+  }
+
+  addChangeProposal(proposal) {
+    const { newState, proposalId } = addChangeProposal(this._state, proposal)
+    this._state = newState
+    return proposalId
+  }
+
+  getChangeProposals(filter = {}) {
+    return getChangeProposals(this._state, filter)
+  }
+
+  getPendingProposals() {
+    return getPendingProposals(this._state)
+  }
+
+  approveProposal(proposalId) {
+    this._state = approveProposal(this._state, proposalId)
+    return this._state.content
+  }
+
+  rejectProposal(proposalId, reason = '') {
+    this._state = rejectProposal(this._state, proposalId, reason)
+    const proposal = this._state.changeProposals.find(p => p.id === proposalId)
+    return proposal
+  }
+
+  approveAllFromAgent(agentId) {
+    const { newState, results } = approveAllFromAgent(this._state, agentId)
+    this._state = newState
+    return results
+  }
+
+  applyChange(proposal) {
+    return applyChange(this._state.content, proposal)
+  }
+
+  addAnnotation(annotation) {
+    const { newState, annotationId } = addAnnotation(this._state, annotation)
+    this._state = newState
+    return annotationId
+  }
+
+  getAnnotations(filter = {}) {
+    return getAnnotations(this._state, filter)
+  }
+
+  getVersionHistory() {
+    return [...this._state.versions]
+  }
+
+  revertToVersion(versionIndex) {
+    this._state = revertToVersion(this._state, versionIndex)
+    return this._state.content
+  }
+
+  updatePendingProposalsAfterChange() {
+    // Now handled internally by approveProposal
+  }
+
   countWords(text) {
-    return text.trim().split(/\s+/).filter(w => w.length > 0).length
+    return countWords(text)
   }
 
-  /**
-   * Compute simple diff between two texts
-   */
   computeDiff(oldText, newText) {
-    // Simple diff - in production, use a proper diff library
-    return {
-      added: newText.length - oldText.length,
-      type: newText.length > oldText.length ? 'addition' : 'deletion'
-    }
+    return computeDiff(oldText, newText)
   }
 
-  /**
-   * Export state for persistence
-   */
   export() {
-    return {
-      content: this.content,
-      metadata: this.metadata,
-      versions: this.versions,
-      changeProposals: this.changeProposals,
-      appliedChanges: this.appliedChanges,
-      annotations: this.annotations
-    }
+    return exportState(this._state)
   }
 
-  /**
-   * Import state from persistence
-   */
   static import(data) {
-    const state = new DocumentState(data.content, data.metadata)
-    state.versions = data.versions || []
-    state.changeProposals = data.changeProposals || []
-    state.appliedChanges = data.appliedChanges || []
-    state.annotations = data.annotations || []
+    const state = new DocumentState()
+    state._state = {
+      ...importState(data),
+      // Preserve content from import data
+      content: data.content
+    }
     return state
   }
 }


### PR DESCRIPTION
## Summary

- Replace mutable `DocumentState` class with plain state objects and pure functions (`createDocumentState`, `updateContent`, `approveProposal`, etc.)
- Replace `useState` + `updateCounter` hack in `AgentContext` with `useReducer`, fixing the bug where `updateDocumentContent` mutated the same object reference (invisible to React)
- Cap version history at 50 entries to prevent unbounded memory growth
- HomePage now depends on `documentContent` from reducer state instead of `updateCounter` + `documentState.getContent()`

## Test plan

- [x] All 231 tests pass (up from 228 — new pure function tests add coverage)
- [x] Production build succeeds
- [x] DocumentState tests rewritten to verify immutability (original state not mutated)
- [x] AgentContext tests updated to use `documentContent` instead of `updateCounter`
- [x] Backward-compatible `DocumentState` class wrapper preserved for agent execution
- [x] Manual smoke test: create document, run agent, approve/reject proposals