### PR TITLE
Add agent system test coverage (Phase 6)

### DIFF
--- a/src/agents/__tests__/argumentStrengthenerAgent.test.js
+++ b/src/agents/__tests__/argumentStrengthenerAgent.test.js
@@ -1,0 +1,239 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { DocumentState } from '../../services/agents/documentState'
+
+vi.mock('../../services/agents/aiService', () => ({
+  makeCompletion: vi.fn()
+}))
+
+import { makeCompletion } from '../../services/agents/aiService'
+import {
+  argumentStrengthenerAgentContract,
+  ARGUMENT_STRENGTHENER_AGENT_ID
+} from '../argumentStrengthenerAgent'
+
+describe('argumentStrengthenerAgent', () => {
+  let documentState
+
+  beforeEach(() => {
+    documentState = new DocumentState(
+      'Remote work increases productivity. Companies should adopt it immediately.',
+      { title: 'Remote Work Argument' }
+    )
+    vi.clearAllMocks()
+  })
+
+  describe('contract', () => {
+    test('has correct id and stage', () => {
+      expect(argumentStrengthenerAgentContract.id).toBe('argument-strengthener-agent')
+      expect(argumentStrengthenerAgentContract.stage).toBe('revise')
+    })
+
+    test('uses very low temperature for logical analysis', () => {
+      expect(argumentStrengthenerAgentContract.config.temperature).toBe(0.2)
+    })
+  })
+
+  describe('execute', () => {
+    test('returns error for empty content', async () => {
+      const emptyDoc = new DocumentState('')
+
+      const result = await argumentStrengthenerAgentContract.execute(emptyDoc)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('No content to analyze')
+      expect(makeCompletion).not.toHaveBeenCalled()
+    })
+
+    test('creates INSERT proposals from argument gaps', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Claim lacks evidence',
+        thesis: 'Remote work is better',
+        claims: [],
+        gaps: [
+          {
+            location: { start: 0, end: 40 },
+            type: 'missing-evidence',
+            description: 'No data supporting productivity claim',
+            impact: 'Core claim unsupported',
+            fix: 'Add productivity study data',
+            priority: 'critical'
+          }
+        ],
+        counterarguments: {},
+        evidenceNeeds: []
+      })
+
+      const result = await argumentStrengthenerAgentContract.execute(documentState)
+
+      expect(result.success).toBe(true)
+      expect(result.proposalsCreated).toBe(1)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals[0].type).toBe('insert')
+      expect(proposals[0].proposedText).toContain('[TK: Add productivity study data]')
+      expect(proposals[0].category).toBe('logic')
+      expect(proposals[0].priority).toBe('critical')
+      expect(proposals[0].agentId).toBe(ARGUMENT_STRENGTHENER_AGENT_ID)
+    })
+
+    test('creates proposals from evidence needs', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Needs more evidence',
+        thesis: 'Remote work thesis',
+        claims: [],
+        gaps: [],
+        counterarguments: {},
+        evidenceNeeds: [
+          {
+            claim: 'Remote work increases productivity',
+            type: 'empirical-data',
+            description: 'Find studies on remote work productivity'
+          },
+          {
+            claim: 'Companies should adopt it',
+            type: 'case-study',
+            description: 'Find company case studies on remote transition'
+          }
+        ]
+      })
+
+      const result = await argumentStrengthenerAgentContract.execute(documentState)
+
+      expect(result.success).toBe(true)
+      expect(result.proposalsCreated).toBe(2)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals[0].proposedText).toContain('[TK:')
+      expect(proposals[0].category).toBe('logic')
+      expect(proposals[0].priority).toBe('important')
+      expect(proposals[1].metadata.evidenceType).toBe('case-study')
+    })
+
+    test('combines gaps and evidence needs', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Multiple issues',
+        thesis: 'Thesis',
+        claims: [],
+        gaps: [
+          {
+            location: { start: 0, end: 10 },
+            type: 'weak-warrant',
+            description: 'Weak connection',
+            impact: 'Unconvincing',
+            fix: 'Explain the mechanism',
+            priority: 'important'
+          }
+        ],
+        counterarguments: {},
+        evidenceNeeds: [
+          {
+            claim: 'Claim X',
+            type: 'expert-testimony',
+            description: 'Find expert opinion'
+          }
+        ]
+      })
+
+      const result = await argumentStrengthenerAgentContract.execute(documentState)
+
+      expect(result.proposalsCreated).toBe(2)
+    })
+
+    test('maps priority correctly for gaps', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Test',
+        gaps: [
+          { location: { start: 0, end: 5 }, type: 'x', description: 'd', impact: 'i', fix: 'f', priority: 'critical' },
+          { location: { start: 5, end: 10 }, type: 'x', description: 'd', impact: 'i', fix: 'f', priority: 'important' },
+          { location: { start: 10, end: 15 }, type: 'x', description: 'd', impact: 'i', fix: 'f', priority: 'minor' }
+        ],
+        evidenceNeeds: []
+      })
+
+      await argumentStrengthenerAgentContract.execute(documentState)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals[0].priority).toBe('critical')
+      expect(proposals[1].priority).toBe('important')
+      expect(proposals[2].priority).toBe('minor')
+    })
+
+    test('skips gaps without required fields', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Test',
+        gaps: [
+          { location: { start: 0, end: 5 }, type: 'x', description: 'd', impact: 'i', fix: 'valid', priority: 'minor' },
+          { type: 'x', description: 'd', impact: 'i', fix: 'no location' },
+          { location: { start: 5, end: 10 } } // no fix
+        ],
+        evidenceNeeds: []
+      })
+
+      await argumentStrengthenerAgentContract.execute(documentState)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals).toHaveLength(1)
+    })
+
+    test('stores gap metadata', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Test',
+        gaps: [
+          {
+            location: { start: 0, end: 10 },
+            type: 'logical-fallacy',
+            description: 'Hasty generalization',
+            impact: 'Weakens argument',
+            fix: 'Add more examples',
+            priority: 'critical'
+          }
+        ],
+        evidenceNeeds: []
+      })
+
+      await argumentStrengthenerAgentContract.execute(documentState)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals[0].metadata.gapType).toBe('logical-fallacy')
+      expect(proposals[0].metadata.impact).toBe('Weakens argument')
+    })
+
+    test('adds annotation with argument analysis', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Argument has gaps',
+        thesis: 'Remote work is productive',
+        claims: [{ claim: 'Productivity rises', hasEvidence: false }],
+        gaps: [],
+        counterarguments: { claim: 'Office culture matters' },
+        evidenceNeeds: []
+      })
+
+      await argumentStrengthenerAgentContract.execute(documentState)
+
+      const annotations = documentState.getAnnotations()
+      expect(annotations).toHaveLength(1)
+      expect(annotations[0].agentId).toBe(ARGUMENT_STRENGTHENER_AGENT_ID)
+      expect(annotations[0].category).toBe('logic')
+      expect(annotations[0].data.thesis).toBe('Remote work is productive')
+      expect(annotations[0].data.counterarguments.claim).toBe('Office culture matters')
+    })
+
+    test('handles invalid response format', async () => {
+      makeCompletion.mockResolvedValue({ noGaps: true })
+
+      const result = await argumentStrengthenerAgentContract.execute(documentState)
+
+      expect(result.success).toBe(true)
+      expect(result.proposalsCreated).toBe(0)
+    })
+
+    test('handles AI service error', async () => {
+      makeCompletion.mockRejectedValue(new Error('Service unavailable'))
+
+      const result = await argumentStrengthenerAgentContract.execute(documentState)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Service unavailable')
+    })
+  })
+})

--- a/src/agents/__tests__/brainstormAgent.test.js
+++ b/src/agents/__tests__/brainstormAgent.test.js
@@ -1,0 +1,157 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { DocumentState } from '../../services/agents/documentState'
+
+// Mock aiService
+vi.mock('../../services/agents/aiService', () => ({
+  makeCompletion: vi.fn()
+}))
+
+import { makeCompletion } from '../../services/agents/aiService'
+import { brainstormAgentContract, BRAINSTORM_AGENT_ID } from '../brainstormAgent'
+
+describe('brainstormAgent', () => {
+  let documentState
+
+  beforeEach(() => {
+    documentState = new DocumentState('Some existing content about technology.', {
+      title: 'Tech Article'
+    })
+    vi.clearAllMocks()
+  })
+
+  describe('contract', () => {
+    test('has correct id and stage', () => {
+      expect(brainstormAgentContract.id).toBe('brainstorm-agent')
+      expect(brainstormAgentContract.stage).toBe('brainstorm')
+    })
+
+    test('uses high temperature for creativity', () => {
+      expect(brainstormAgentContract.config.temperature).toBe(0.9)
+    })
+
+    test('has execute function', () => {
+      expect(typeof brainstormAgentContract.execute).toBe('function')
+    })
+  })
+
+  describe('execute', () => {
+    test('calls makeCompletion with json responseFormat', async () => {
+      makeCompletion.mockResolvedValue({
+        ideas: [
+          { title: 'Idea 1', description: 'Description 1', reasoning: 'Reasoning 1' }
+        ]
+      })
+
+      await brainstormAgentContract.execute(documentState)
+
+      expect(makeCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          responseFormat: 'json',
+          model: 'gpt-4o',
+          temperature: 0.9
+        })
+      )
+    })
+
+    test('creates proposals for each idea returned', async () => {
+      makeCompletion.mockResolvedValue({
+        ideas: [
+          { title: 'Idea A', description: 'Desc A', reasoning: 'Why A' },
+          { title: 'Idea B', description: 'Desc B', reasoning: 'Why B' },
+          { title: 'Idea C', description: 'Desc C', reasoning: 'Why C' }
+        ]
+      })
+
+      const result = await brainstormAgentContract.execute(documentState)
+
+      expect(result.success).toBe(true)
+      expect(result.proposalsCreated).toBe(3)
+      expect(documentState.getPendingProposals()).toHaveLength(3)
+    })
+
+    test('creates INSERT-type proposals at end of document', async () => {
+      makeCompletion.mockResolvedValue({
+        ideas: [
+          { title: 'New Idea', description: 'A new direction', reasoning: 'Worth exploring' }
+        ]
+      })
+
+      await brainstormAgentContract.execute(documentState)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals[0].type).toBe('insert')
+      expect(proposals[0].proposedText).toContain('## New Idea')
+      expect(proposals[0].proposedText).toContain('A new direction')
+      expect(proposals[0].agentId).toBe(BRAINSTORM_AGENT_ID)
+      expect(proposals[0].category).toBe('content')
+      expect(proposals[0].priority).toBe('minor')
+    })
+
+    test('adds annotation with brainstorm results', async () => {
+      makeCompletion.mockResolvedValue({
+        ideas: [{ title: 'Idea', description: 'Desc', reasoning: 'Why' }]
+      })
+
+      await brainstormAgentContract.execute(documentState)
+
+      const annotations = documentState.getAnnotations()
+      expect(annotations).toHaveLength(1)
+      expect(annotations[0].agentId).toBe(BRAINSTORM_AGENT_ID)
+      expect(annotations[0].category).toBe('brainstorm')
+    })
+
+    test('passes focusArea and count options', async () => {
+      makeCompletion.mockResolvedValue({ ideas: [] })
+
+      await brainstormAgentContract.execute(documentState, {
+        focusArea: 'counterarguments',
+        count: 3,
+        prompt: 'Focus on weak points'
+      })
+
+      const call = makeCompletion.mock.calls[0][0]
+      expect(call.systemPrompt).toContain('counterarguments')
+      expect(call.userPrompt).toContain('3 counterarguments ideas')
+      expect(call.userPrompt).toContain('Focus on weak points')
+    })
+
+    test('returns empty proposals for invalid response format', async () => {
+      makeCompletion.mockResolvedValue({ notIdeas: 'bad format' })
+
+      const result = await brainstormAgentContract.execute(documentState)
+
+      expect(result.success).toBe(true)
+      expect(result.proposalsCreated).toBe(0)
+    })
+
+    test('handles AI service error gracefully', async () => {
+      makeCompletion.mockRejectedValue(new Error('API key not configured'))
+
+      const result = await brainstormAgentContract.execute(documentState)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('API key not configured')
+    })
+
+    test('includes document content in user prompt', async () => {
+      makeCompletion.mockResolvedValue({ ideas: [] })
+
+      await brainstormAgentContract.execute(documentState)
+
+      const call = makeCompletion.mock.calls[0][0]
+      expect(call.userPrompt).toContain('Some existing content about technology.')
+    })
+
+    test('works with empty document', async () => {
+      const emptyDoc = new DocumentState('')
+      makeCompletion.mockResolvedValue({
+        ideas: [{ title: 'Start Here', description: 'Begin with...', reasoning: 'Fresh start' }]
+      })
+
+      const result = await brainstormAgentContract.execute(emptyDoc)
+
+      expect(result.success).toBe(true)
+      expect(result.proposalsCreated).toBe(1)
+    })
+  })
+})

--- a/src/agents/__tests__/draftAgent.test.js
+++ b/src/agents/__tests__/draftAgent.test.js
@@ -1,0 +1,143 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { DocumentState } from '../../services/agents/documentState'
+
+vi.mock('../../services/agents/aiService', () => ({
+  makeCompletion: vi.fn(),
+  makeStreamingCompletion: vi.fn()
+}))
+
+import { makeCompletion, makeStreamingCompletion } from '../../services/agents/aiService'
+import { draftAgentContract, DRAFT_AGENT_ID } from '../draftAgent'
+
+describe('draftAgent', () => {
+  let documentState
+
+  beforeEach(() => {
+    documentState = new DocumentState('Existing content here.', {
+      title: 'My Draft'
+    })
+    vi.clearAllMocks()
+  })
+
+  describe('contract', () => {
+    test('has correct id and stage', () => {
+      expect(draftAgentContract.id).toBe('draft-agent')
+      expect(draftAgentContract.stage).toBe('draft')
+    })
+
+    test('uses moderately high temperature', () => {
+      expect(draftAgentContract.config.temperature).toBe(0.8)
+    })
+  })
+
+  describe('execute - non-streaming', () => {
+    test('calls makeCompletion when no onProgress callback', async () => {
+      makeCompletion.mockResolvedValue('Generated draft content for the article.')
+
+      const result = await draftAgentContract.execute(documentState)
+
+      expect(makeCompletion).toHaveBeenCalledTimes(1)
+      expect(makeStreamingCompletion).not.toHaveBeenCalled()
+      expect(result.success).toBe(true)
+      expect(result.proposalsCreated).toBe(1)
+      expect(result.draftContent).toBe('Generated draft content for the article.')
+    })
+
+    test('creates REPLACE proposal for non-empty document', async () => {
+      makeCompletion.mockResolvedValue('New draft replaces old content.')
+
+      await draftAgentContract.execute(documentState)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals).toHaveLength(1)
+      expect(proposals[0].type).toBe('replace')
+      expect(proposals[0].originalText).toBe('Existing content here.')
+      expect(proposals[0].proposedText).toBe('New draft replaces old content.')
+      expect(proposals[0].agentId).toBe(DRAFT_AGENT_ID)
+      expect(proposals[0].category).toBe('content')
+      expect(proposals[0].priority).toBe('important')
+    })
+
+    test('creates REPLACE proposal for empty document', async () => {
+      const emptyDoc = new DocumentState('')
+      makeCompletion.mockResolvedValue('Brand new draft.')
+
+      await draftAgentContract.execute(emptyDoc)
+
+      const proposals = emptyDoc.getPendingProposals()
+      expect(proposals[0].type).toBe('replace')
+      expect(proposals[0].originalText).toBe('')
+      expect(proposals[0].location).toEqual({ start: 0, end: 0 })
+    })
+
+    test('includes word count and TK count in proposal metadata', async () => {
+      makeCompletion.mockResolvedValue(
+        'This is a draft with [TK: cite source] and [TK: add example] placeholders.'
+      )
+
+      await draftAgentContract.execute(documentState)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals[0].metadata.wordCount).toBeGreaterThan(0)
+      expect(proposals[0].metadata.tkCount).toBe(2)
+    })
+
+    test('adds annotation with word count', async () => {
+      makeCompletion.mockResolvedValue('Five words in this draft.')
+
+      await draftAgentContract.execute(documentState)
+
+      const annotations = documentState.getAnnotations()
+      expect(annotations).toHaveLength(1)
+      expect(annotations[0].agentId).toBe(DRAFT_AGENT_ID)
+      expect(annotations[0].content).toContain('5 words')
+    })
+
+    test('passes targetWords and outline in prompt', async () => {
+      makeCompletion.mockResolvedValue('Draft output.')
+
+      await draftAgentContract.execute(documentState, {
+        prompt: 'Write about AI',
+        outline: '1. Intro\n2. Body\n3. Conclusion',
+        targetWords: 1000
+      })
+
+      const call = makeCompletion.mock.calls[0][0]
+      expect(call.userPrompt).toContain('Write about AI')
+      expect(call.userPrompt).toContain('1. Intro')
+      expect(call.userPrompt).toContain('1000 words')
+    })
+  })
+
+  describe('execute - streaming', () => {
+    test('calls makeStreamingCompletion when onProgress provided', async () => {
+      const abortFn = vi.fn()
+      makeStreamingCompletion.mockImplementation(async (opts, onChunk) => {
+        onChunk('First ')
+        onChunk('chunk.')
+        return abortFn
+      })
+
+      const onProgress = vi.fn()
+      const result = await draftAgentContract.execute(documentState, { onProgress })
+
+      expect(makeStreamingCompletion).toHaveBeenCalledTimes(1)
+      expect(makeCompletion).not.toHaveBeenCalled()
+      expect(onProgress).toHaveBeenCalledWith('First ')
+      expect(onProgress).toHaveBeenCalledWith('First chunk.')
+      expect(result.success).toBe(true)
+      expect(result.abort).toBe(abortFn)
+    })
+  })
+
+  describe('error handling', () => {
+    test('returns failure on AI service error', async () => {
+      makeCompletion.mockRejectedValue(new Error('Rate limit exceeded'))
+
+      const result = await draftAgentContract.execute(documentState)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Rate limit exceeded')
+    })
+  })
+})

--- a/src/agents/__tests__/editorAgent.test.js
+++ b/src/agents/__tests__/editorAgent.test.js
@@ -1,0 +1,188 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { DocumentState } from '../../services/agents/documentState'
+
+vi.mock('../../services/agents/aiService', () => ({
+  makeCompletion: vi.fn()
+}))
+
+import { makeCompletion } from '../../services/agents/aiService'
+import { editorAgentContract, EDITOR_AGENT_ID } from '../editorAgent'
+
+describe('editorAgent', () => {
+  let documentState
+
+  beforeEach(() => {
+    documentState = new DocumentState('It is important to note that the end result was achieved.', {
+      title: 'Draft Article'
+    })
+    vi.clearAllMocks()
+  })
+
+  describe('contract', () => {
+    test('has correct id and stage', () => {
+      expect(editorAgentContract.id).toBe('editor-agent')
+      expect(editorAgentContract.stage).toBe('edit')
+    })
+
+    test('uses low temperature for precision', () => {
+      expect(editorAgentContract.config.temperature).toBe(0.3)
+    })
+  })
+
+  describe('execute', () => {
+    test('returns error for empty content', async () => {
+      const emptyDoc = new DocumentState('')
+
+      const result = await editorAgentContract.execute(emptyDoc)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('No content to edit')
+      expect(makeCompletion).not.toHaveBeenCalled()
+    })
+
+    test('creates proposals from edits', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Several filler phrases found',
+        improvements: { clarity: [], concision: ['Remove filler'], style: [] },
+        patterns: ['Filler phrases'],
+        edits: [
+          {
+            location: { start: 0, end: 30 },
+            before: 'It is important to note that',
+            after: 'Note:',
+            reason: 'Filler phrase',
+            type: 'concision',
+            priority: 'important'
+          },
+          {
+            location: { start: 35, end: 45 },
+            before: 'end result',
+            after: 'result',
+            reason: 'Redundancy',
+            type: 'concision',
+            priority: 'minor'
+          }
+        ]
+      })
+
+      const result = await editorAgentContract.execute(documentState)
+
+      expect(result.success).toBe(true)
+      expect(result.proposalsCreated).toBe(2)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals).toHaveLength(2)
+      expect(proposals[0].type).toBe('replace')
+      expect(proposals[0].agentId).toBe(EDITOR_AGENT_ID)
+    })
+
+    test('maps all edit types to STYLE category', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Test',
+        edits: [
+          { location: { start: 0, end: 5 }, after: 'a', type: 'clarity', priority: 'minor' },
+          { location: { start: 5, end: 10 }, after: 'b', type: 'concision', priority: 'minor' },
+          { location: { start: 10, end: 15 }, after: 'c', type: 'style', priority: 'minor' }
+        ]
+      })
+
+      await editorAgentContract.execute(documentState)
+
+      const proposals = documentState.getPendingProposals()
+      proposals.forEach(p => {
+        expect(p.category).toBe('style')
+      })
+    })
+
+    test('maps priority correctly', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Test',
+        edits: [
+          { location: { start: 0, end: 5 }, after: 'a', type: 'style', priority: 'critical' },
+          { location: { start: 5, end: 10 }, after: 'b', type: 'style', priority: 'important' },
+          { location: { start: 10, end: 15 }, after: 'c', type: 'style', priority: 'minor' }
+        ]
+      })
+
+      await editorAgentContract.execute(documentState)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals[0].priority).toBe('critical')
+      expect(proposals[1].priority).toBe('important')
+      expect(proposals[2].priority).toBe('minor')
+    })
+
+    test('skips edits without required fields', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Test',
+        edits: [
+          { location: { start: 0, end: 5 }, after: 'valid', type: 'style', priority: 'minor' },
+          { after: 'no location' },
+          { location: { start: 5, end: 10 } } // no after
+        ]
+      })
+
+      await editorAgentContract.execute(documentState)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals).toHaveLength(1)
+    })
+
+    test('stores editType in proposal metadata', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Test',
+        edits: [
+          { location: { start: 0, end: 5 }, after: 'new', type: 'clarity', priority: 'minor' }
+        ]
+      })
+
+      await editorAgentContract.execute(documentState)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals[0].metadata.editType).toBe('clarity')
+    })
+
+    test('adds annotation with improvements and patterns', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Good prose overall',
+        improvements: { clarity: ['Better'], concision: [], style: [] },
+        patterns: ['Passive voice'],
+        edits: []
+      })
+
+      await editorAgentContract.execute(documentState)
+
+      const annotations = documentState.getAnnotations()
+      expect(annotations).toHaveLength(1)
+      expect(annotations[0].agentId).toBe(EDITOR_AGENT_ID)
+      expect(annotations[0].data.patterns).toContain('Passive voice')
+    })
+
+    test('passes focus option to system prompt', async () => {
+      makeCompletion.mockResolvedValue({ summary: 'Test', edits: [] })
+
+      await editorAgentContract.execute(documentState, { focus: 'concision' })
+
+      const call = makeCompletion.mock.calls[0][0]
+      expect(call.systemPrompt).toContain('concision')
+    })
+
+    test('handles invalid response format', async () => {
+      makeCompletion.mockResolvedValue({ noEdits: true })
+
+      const result = await editorAgentContract.execute(documentState)
+
+      expect(result.success).toBe(true)
+      expect(result.proposalsCreated).toBe(0)
+    })
+
+    test('handles AI service error', async () => {
+      makeCompletion.mockRejectedValue(new Error('Invalid API key'))
+
+      const result = await editorAgentContract.execute(documentState)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Invalid API key')
+    })
+  })
+})

--- a/src/agents/__tests__/revisionAgent.test.js
+++ b/src/agents/__tests__/revisionAgent.test.js
@@ -1,0 +1,226 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { DocumentState } from '../../services/agents/documentState'
+
+vi.mock('../../services/agents/aiService', () => ({
+  makeCompletion: vi.fn()
+}))
+
+import { makeCompletion } from '../../services/agents/aiService'
+import { revisionAgentContract, REVISION_AGENT_ID } from '../revisionAgent'
+
+describe('revisionAgent', () => {
+  let documentState
+
+  beforeEach(() => {
+    documentState = new DocumentState('The technology is very important and it has many uses.', {
+      title: 'Tech Article'
+    })
+    vi.clearAllMocks()
+  })
+
+  describe('contract', () => {
+    test('has correct id and stage', () => {
+      expect(revisionAgentContract.id).toBe('revision-agent')
+      expect(revisionAgentContract.stage).toBe('revise')
+    })
+
+    test('uses low temperature for analytical work', () => {
+      expect(revisionAgentContract.config.temperature).toBe(0.3)
+    })
+  })
+
+  describe('execute', () => {
+    test('returns error for empty content', async () => {
+      const emptyDoc = new DocumentState('')
+
+      const result = await revisionAgentContract.execute(emptyDoc)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('No content to revise')
+      expect(makeCompletion).not.toHaveBeenCalled()
+    })
+
+    test('returns error for whitespace-only content', async () => {
+      const emptyDoc = new DocumentState('   \n\t  ')
+
+      const result = await revisionAgentContract.execute(emptyDoc)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('No content to revise')
+    })
+
+    test('calls makeCompletion with json format', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Needs work',
+        assessments: {},
+        priorities: [],
+        revisions: []
+      })
+
+      await revisionAgentContract.execute(documentState)
+
+      expect(makeCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          responseFormat: 'json',
+          temperature: 0.3
+        })
+      )
+    })
+
+    test('creates proposals from revisions', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Several improvements needed',
+        assessments: { structure: { score: 'good' } },
+        priorities: ['Fix weak verbs'],
+        revisions: [
+          {
+            location: { start: 0, end: 20 },
+            problem: 'is very important',
+            diagnosis: 'Weak verb + vague qualifier',
+            fix: 'matters deeply',
+            principle: 'Use strong verbs',
+            category: 'style',
+            priority: 'important'
+          },
+          {
+            location: { start: 30, end: 50 },
+            problem: 'has many uses',
+            diagnosis: 'Vague language',
+            fix: 'powers three industries',
+            principle: 'Be specific',
+            category: 'mechanics',
+            priority: 'minor'
+          }
+        ]
+      })
+
+      const result = await revisionAgentContract.execute(documentState)
+
+      expect(result.success).toBe(true)
+      expect(result.proposalsCreated).toBe(2)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals).toHaveLength(2)
+      expect(proposals[0].type).toBe('replace')
+      expect(proposals[0].agentId).toBe(REVISION_AGENT_ID)
+    })
+
+    test('maps category correctly', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Test',
+        revisions: [
+          { location: { start: 0, end: 5 }, fix: 'a', category: 'structure', priority: 'minor' },
+          { location: { start: 5, end: 10 }, fix: 'b', category: 'style', priority: 'minor' },
+          { location: { start: 10, end: 15 }, fix: 'c', category: 'mechanics', priority: 'minor' }
+        ]
+      })
+
+      await revisionAgentContract.execute(documentState)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals[0].category).toBe('structure')
+      expect(proposals[1].category).toBe('style')
+      expect(proposals[2].category).toBe('mechanics')
+    })
+
+    test('maps priority correctly', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Test',
+        revisions: [
+          { location: { start: 0, end: 5 }, fix: 'a', category: 'style', priority: 'critical' },
+          { location: { start: 5, end: 10 }, fix: 'b', category: 'style', priority: 'important' },
+          { location: { start: 10, end: 15 }, fix: 'c', category: 'style', priority: 'minor' }
+        ]
+      })
+
+      await revisionAgentContract.execute(documentState)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals[0].priority).toBe('critical')
+      expect(proposals[1].priority).toBe('important')
+      expect(proposals[2].priority).toBe('minor')
+    })
+
+    test('skips revisions without required fields', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Test',
+        revisions: [
+          { location: { start: 0, end: 5 }, fix: 'valid', category: 'style', priority: 'minor' },
+          { fix: 'no location' },
+          { location: { start: 5, end: 10 } } // no fix
+        ]
+      })
+
+      await revisionAgentContract.execute(documentState)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals).toHaveLength(1)
+    })
+
+    test('includes diagnosis and principle in rationale', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Test',
+        revisions: [
+          {
+            location: { start: 0, end: 5 },
+            problem: 'old',
+            diagnosis: 'Weak verb',
+            fix: 'new',
+            principle: 'Use active voice',
+            category: 'style',
+            priority: 'minor'
+          }
+        ]
+      })
+
+      await revisionAgentContract.execute(documentState)
+
+      const proposals = documentState.getPendingProposals()
+      expect(proposals[0].rationale).toContain('Weak verb')
+      expect(proposals[0].rationale).toContain('Use active voice')
+    })
+
+    test('adds annotation with assessment data', async () => {
+      makeCompletion.mockResolvedValue({
+        summary: 'Overall assessment',
+        assessments: { structure: { score: 'good' } },
+        priorities: ['Fix weak verbs'],
+        revisions: []
+      })
+
+      await revisionAgentContract.execute(documentState)
+
+      const annotations = documentState.getAnnotations()
+      expect(annotations).toHaveLength(1)
+      expect(annotations[0].agentId).toBe(REVISION_AGENT_ID)
+      expect(annotations[0].content).toBe('Overall assessment')
+    })
+
+    test('passes depth option to system prompt', async () => {
+      makeCompletion.mockResolvedValue({ summary: 'Test', revisions: [] })
+
+      await revisionAgentContract.execute(documentState, { depth: 'light' })
+
+      const call = makeCompletion.mock.calls[0][0]
+      expect(call.systemPrompt).toContain('Light pass')
+    })
+
+    test('handles invalid response format', async () => {
+      makeCompletion.mockResolvedValue({ noRevisions: true })
+
+      const result = await revisionAgentContract.execute(documentState)
+
+      expect(result.success).toBe(true)
+      expect(result.proposalsCreated).toBe(0)
+    })
+
+    test('handles AI service error', async () => {
+      makeCompletion.mockRejectedValue(new Error('Network error'))
+
+      const result = await revisionAgentContract.execute(documentState)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('Network error')
+    })
+  })
+})

--- a/src/contexts/__tests__/AgentContext.execution.test.jsx
+++ b/src/contexts/__tests__/AgentContext.execution.test.jsx
@@ -235,9 +235,8 @@ describe('AgentContext - Execution', () => {
       })
     })
 
-    // TODO: Fix timing issues with fake timers
-    test.skip('clears executionProgress after 3 seconds', async () => {
-      vi.useFakeTimers()
+    test('clears executionProgress after 3 seconds', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true })
 
       mockOrchestrator.executeAgent.mockResolvedValue({ success: true })
 
@@ -259,29 +258,26 @@ describe('AgentContext - Execution', () => {
         </AgentProvider>
       )
 
-      screen.getByText('Initialize').click()
-      screen.getByText('Execute').click()
-
-      // Run pending promises
-      await vi.runAllTimersAsync()
+      // Use fireEvent (not userEvent) with fake timers to avoid async timing conflicts
+      fireEvent.click(screen.getByText('Initialize'))
+      fireEvent.click(screen.getByText('Execute'))
 
       await waitFor(() => {
         expect(screen.getByTestId('progress')).toHaveTextContent('yes')
       })
 
-      // Fast-forward 3 seconds
+      // Fast-forward 3 seconds to trigger the setTimeout(() => setExecutionProgress(null), 3000)
       await vi.advanceTimersByTimeAsync(3000)
 
       await waitFor(() => {
         expect(screen.getByTestId('progress')).toHaveTextContent('no')
       })
 
-      vi.restoreAllTimers()
+      vi.useRealTimers()
     })
   })
 
-  // TODO: Fix timing issues with executePipeline tests
-  describe.skip('executePipeline', () => {
+  describe('executePipeline', () => {
     test('throws error when no document initialized', async () => {
       let caughtError = null
 
@@ -307,7 +303,7 @@ describe('AgentContext - Execution', () => {
         </AgentProvider>
       )
 
-      screen.getByText('Execute').click()
+      fireEvent.click(screen.getByText('Execute'))
 
       await waitFor(() => {
         expect(caughtError).not.toBeNull()
@@ -316,8 +312,9 @@ describe('AgentContext - Execution', () => {
     })
 
     test('sets isExecuting to true during pipeline execution', async () => {
+      let resolveExecution
       mockOrchestrator.executePipeline.mockImplementation(
-        () => new Promise(resolve => setTimeout(() => resolve({ status: 'completed' }), 50))
+        () => new Promise(resolve => { resolveExecution = () => resolve({ status: 'completed' }) })
       )
 
       function PipelineComponent() {
@@ -338,16 +335,23 @@ describe('AgentContext - Execution', () => {
         </AgentProvider>
       )
 
-      screen.getByText('Initialize').click()
-      screen.getByText('Execute').click()
+      fireEvent.click(screen.getByText('Initialize'))
+
+      // Wait for state to settle after initialization
+      await waitFor(() => {})
+
+      fireEvent.click(screen.getByText('Execute'))
 
       await waitFor(() => {
         expect(screen.getByTestId('executing')).toHaveTextContent('yes')
       })
 
+      // Resolve the execution
+      resolveExecution()
+
       await waitFor(() => {
         expect(screen.getByTestId('executing')).toHaveTextContent('no')
-      }, { timeout: 200 })
+      })
     })
 
     test('passes callbacks to orchestrator', async () => {
@@ -370,8 +374,11 @@ describe('AgentContext - Execution', () => {
         </AgentProvider>
       )
 
-      screen.getByText('Initialize').click()
-      screen.getByText('Execute').click()
+      fireEvent.click(screen.getByText('Initialize'))
+
+      await waitFor(() => {})
+
+      fireEvent.click(screen.getByText('Execute'))
 
       await waitFor(() => {
         expect(mockOrchestrator.executePipeline).toHaveBeenCalledWith(
@@ -388,7 +395,6 @@ describe('AgentContext - Execution', () => {
 
     test('updates currentStep during pipeline execution', async () => {
       mockOrchestrator.executePipeline.mockImplementation((id, doc, options) => {
-        // Simulate step start
         options.onStepStart(0, { agentId: 'agent-1' })
         return Promise.resolve({ status: 'completed' })
       })
@@ -412,8 +418,11 @@ describe('AgentContext - Execution', () => {
         </AgentProvider>
       )
 
-      screen.getByText('Initialize').click()
-      screen.getByText('Execute').click()
+      fireEvent.click(screen.getByText('Initialize'))
+
+      await waitFor(() => {})
+
+      fireEvent.click(screen.getByText('Execute'))
 
       await waitFor(() => {
         expect(screen.getByTestId('step-index')).toHaveTextContent('0')
@@ -441,8 +450,11 @@ describe('AgentContext - Execution', () => {
         </AgentProvider>
       )
 
-      screen.getByText('Initialize').click()
-      screen.getByText('Execute').click()
+      fireEvent.click(screen.getByText('Initialize'))
+
+      await waitFor(() => {})
+
+      fireEvent.click(screen.getByText('Execute'))
 
       await waitFor(() => {
         expect(screen.getByTestId('step')).toHaveTextContent('no')
@@ -473,8 +485,11 @@ describe('AgentContext - Execution', () => {
         </AgentProvider>
       )
 
-      screen.getByText('Initialize').click()
-      screen.getByText('Execute').click()
+      fireEvent.click(screen.getByText('Initialize'))
+
+      await waitFor(() => {})
+
+      fireEvent.click(screen.getByText('Execute'))
 
       await waitFor(() => {
         expect(screen.getByTestId('status')).toHaveTextContent('failed')

--- a/src/contexts/__tests__/AgentContext.execution.test.jsx
+++ b/src/contexts/__tests__/AgentContext.execution.test.jsx
@@ -238,42 +238,44 @@ describe('AgentContext - Execution', () => {
     test('clears executionProgress after 3 seconds', async () => {
       vi.useFakeTimers({ shouldAdvanceTime: true })
 
-      mockOrchestrator.executeAgent.mockResolvedValue({ success: true })
+      try {
+        mockOrchestrator.executeAgent.mockResolvedValue({ success: true })
 
-      function ProgressComponent() {
-        const { initializeDocument, executeAgent, executionProgress } = useAgents()
+        function ProgressComponent() {
+          const { initializeDocument, executeAgent, executionProgress } = useAgents()
 
-        return (
-          <div>
-            <span data-testid="progress">{executionProgress ? 'yes' : 'no'}</span>
-            <button onClick={() => initializeDocument('Test')}>Initialize</button>
-            <button onClick={() => executeAgent('test-agent')}>Execute</button>
-          </div>
+          return (
+            <div>
+              <span data-testid="progress">{executionProgress ? 'yes' : 'no'}</span>
+              <button onClick={() => initializeDocument('Test')}>Initialize</button>
+              <button onClick={() => executeAgent('test-agent')}>Execute</button>
+            </div>
+          )
+        }
+
+        render(
+          <AgentProvider>
+            <ProgressComponent />
+          </AgentProvider>
         )
+
+        // Use fireEvent (not userEvent) with fake timers to avoid async timing conflicts
+        fireEvent.click(screen.getByText('Initialize'))
+        fireEvent.click(screen.getByText('Execute'))
+
+        await waitFor(() => {
+          expect(screen.getByTestId('progress')).toHaveTextContent('yes')
+        })
+
+        // Fast-forward 3 seconds to trigger the setTimeout(() => setExecutionProgress(null), 3000)
+        await vi.advanceTimersByTimeAsync(3000)
+
+        await waitFor(() => {
+          expect(screen.getByTestId('progress')).toHaveTextContent('no')
+        })
+      } finally {
+        vi.useRealTimers()
       }
-
-      render(
-        <AgentProvider>
-          <ProgressComponent />
-        </AgentProvider>
-      )
-
-      // Use fireEvent (not userEvent) with fake timers to avoid async timing conflicts
-      fireEvent.click(screen.getByText('Initialize'))
-      fireEvent.click(screen.getByText('Execute'))
-
-      await waitFor(() => {
-        expect(screen.getByTestId('progress')).toHaveTextContent('yes')
-      })
-
-      // Fast-forward 3 seconds to trigger the setTimeout(() => setExecutionProgress(null), 3000)
-      await vi.advanceTimersByTimeAsync(3000)
-
-      await waitFor(() => {
-        expect(screen.getByTestId('progress')).toHaveTextContent('no')
-      })
-
-      vi.useRealTimers()
     })
   })
 

--- a/src/contexts/__tests__/AgentContext.execution.test.jsx
+++ b/src/contexts/__tests__/AgentContext.execution.test.jsx
@@ -320,10 +320,11 @@ describe('AgentContext - Execution', () => {
       )
 
       function PipelineComponent() {
-        const { initializeDocument, executePipeline, isExecuting } = useAgents()
+        const { initializeDocument, executePipeline, isExecuting, documentContent } = useAgents()
 
         return (
           <div>
+            {documentContent !== null && <span data-testid="initialized" />}
             <span data-testid="executing">{isExecuting ? 'yes' : 'no'}</span>
             <button onClick={() => initializeDocument('Test')}>Initialize</button>
             <button onClick={() => executePipeline('test-pipeline').catch(() => {})}>Execute</button>
@@ -339,8 +340,9 @@ describe('AgentContext - Execution', () => {
 
       fireEvent.click(screen.getByText('Initialize'))
 
-      // Wait for state to settle after initialization
-      await waitFor(() => {})
+      await waitFor(() => {
+        expect(screen.getByTestId('initialized')).toBeInTheDocument()
+      })
 
       fireEvent.click(screen.getByText('Execute'))
 
@@ -360,10 +362,11 @@ describe('AgentContext - Execution', () => {
       mockOrchestrator.executePipeline.mockResolvedValue({ status: 'completed' })
 
       function CallbackComponent() {
-        const { initializeDocument, executePipeline } = useAgents()
+        const { initializeDocument, executePipeline, documentContent } = useAgents()
 
         return (
           <div>
+            {documentContent !== null && <span data-testid="initialized" />}
             <button onClick={() => initializeDocument('Test')}>Initialize</button>
             <button onClick={() => executePipeline('test-pipeline').catch(() => {})}>Execute</button>
           </div>
@@ -378,7 +381,9 @@ describe('AgentContext - Execution', () => {
 
       fireEvent.click(screen.getByText('Initialize'))
 
-      await waitFor(() => {})
+      await waitFor(() => {
+        expect(screen.getByTestId('initialized')).toBeInTheDocument()
+      })
 
       fireEvent.click(screen.getByText('Execute'))
 
@@ -402,10 +407,11 @@ describe('AgentContext - Execution', () => {
       })
 
       function StepComponent() {
-        const { initializeDocument, executePipeline, currentStep } = useAgents()
+        const { initializeDocument, executePipeline, currentStep, documentContent } = useAgents()
 
         return (
           <div>
+            {documentContent !== null && <span data-testid="initialized" />}
             <span data-testid="step">{currentStep ? 'yes' : 'no'}</span>
             <span data-testid="step-index">{currentStep?.stepIndex ?? 'none'}</span>
             <button onClick={() => initializeDocument('Test')}>Initialize</button>
@@ -422,7 +428,9 @@ describe('AgentContext - Execution', () => {
 
       fireEvent.click(screen.getByText('Initialize'))
 
-      await waitFor(() => {})
+      await waitFor(() => {
+        expect(screen.getByTestId('initialized')).toBeInTheDocument()
+      })
 
       fireEvent.click(screen.getByText('Execute'))
 
@@ -435,10 +443,11 @@ describe('AgentContext - Execution', () => {
       mockOrchestrator.executePipeline.mockResolvedValue({ status: 'completed' })
 
       function StepComponent() {
-        const { initializeDocument, executePipeline, currentStep } = useAgents()
+        const { initializeDocument, executePipeline, currentStep, documentContent } = useAgents()
 
         return (
           <div>
+            {documentContent !== null && <span data-testid="initialized" />}
             <span data-testid="step">{currentStep ? 'yes' : 'no'}</span>
             <button onClick={() => initializeDocument('Test')}>Initialize</button>
             <button onClick={() => executePipeline('test-pipeline').catch(() => {})}>Execute</button>
@@ -454,7 +463,9 @@ describe('AgentContext - Execution', () => {
 
       fireEvent.click(screen.getByText('Initialize'))
 
-      await waitFor(() => {})
+      await waitFor(() => {
+        expect(screen.getByTestId('initialized')).toBeInTheDocument()
+      })
 
       fireEvent.click(screen.getByText('Execute'))
 
@@ -467,10 +478,11 @@ describe('AgentContext - Execution', () => {
       mockOrchestrator.executePipeline.mockRejectedValue(new Error('Pipeline failed'))
 
       function ErrorComponent() {
-        const { initializeDocument, executePipeline, executionProgress } = useAgents()
+        const { initializeDocument, executePipeline, executionProgress, documentContent } = useAgents()
 
         return (
           <div>
+            {documentContent !== null && <span data-testid="initialized" />}
             <span data-testid="status">{executionProgress?.status || 'none'}</span>
             <span data-testid="error">{executionProgress?.error || 'none'}</span>
             <button onClick={() => initializeDocument('Test')}>Initialize</button>
@@ -489,7 +501,9 @@ describe('AgentContext - Execution', () => {
 
       fireEvent.click(screen.getByText('Initialize'))
 
-      await waitFor(() => {})
+      await waitFor(() => {
+        expect(screen.getByTestId('initialized')).toBeInTheDocument()
+      })
 
       fireEvent.click(screen.getByText('Execute'))
 

--- a/src/services/agents/__tests__/aiService.test.js
+++ b/src/services/agents/__tests__/aiService.test.js
@@ -1,0 +1,474 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { makeCompletion, makeStreamingCompletion, estimateTokens, isApiKeyConfigured } from '../aiService'
+
+// Mock fetch globally
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+describe('aiService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Reset storage mocks
+    window.secureStorage = undefined
+    localStorage.getItem.mockReturnValue(null)
+    // Reset import.meta.env — use delete so the value is truly absent
+    delete import.meta.env.VITE_OPENAI_API_KEY
+  })
+
+  describe('API key retrieval', () => {
+    test('throws when no API key is available', async () => {
+      await expect(
+        makeCompletion({ systemPrompt: 'test', userPrompt: 'test' })
+      ).rejects.toThrow('OpenAI API key not configured')
+    })
+
+    test('uses secureStorage when available', async () => {
+      window.secureStorage = {
+        get: vi.fn().mockResolvedValue('sk-secure-key')
+      }
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: 'response' } }]
+        })
+      })
+
+      await makeCompletion({ systemPrompt: 'sys', userPrompt: 'user' })
+
+      expect(window.secureStorage.get).toHaveBeenCalledWith('openai_api_key')
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/ai/completion',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-API-Key': 'sk-secure-key'
+          })
+        })
+      )
+    })
+
+    test('falls back to localStorage when secureStorage has no key', async () => {
+      window.secureStorage = {
+        get: vi.fn().mockResolvedValue(null)
+      }
+      localStorage.getItem.mockReturnValue('sk-local-key')
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: 'response' } }]
+        })
+      })
+
+      await makeCompletion({ systemPrompt: 'sys', userPrompt: 'user' })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/ai/completion',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-API-Key': 'sk-local-key'
+          })
+        })
+      )
+    })
+
+    test('falls back to localStorage when secureStorage throws', async () => {
+      window.secureStorage = {
+        get: vi.fn().mockRejectedValue(new Error('IPC error'))
+      }
+      localStorage.getItem.mockReturnValue('sk-local-key')
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: 'response' } }]
+        })
+      })
+
+      await makeCompletion({ systemPrompt: 'sys', userPrompt: 'user' })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/ai/completion',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-API-Key': 'sk-local-key'
+          })
+        })
+      )
+    })
+
+    test('falls back to env variable when no storage key', async () => {
+      import.meta.env.VITE_OPENAI_API_KEY = 'sk-env-key'
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: 'response' } }]
+        })
+      })
+
+      await makeCompletion({ systemPrompt: 'sys', userPrompt: 'user' })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/ai/completion',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-API-Key': 'sk-env-key'
+          })
+        })
+      )
+    })
+  })
+
+  describe('makeCompletion', () => {
+    beforeEach(() => {
+      localStorage.getItem.mockReturnValue('sk-test-key')
+    })
+
+    test('sends correct request body', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: 'AI response' } }]
+        })
+      })
+
+      await makeCompletion({
+        systemPrompt: 'You are helpful',
+        userPrompt: 'Hello',
+        model: 'gpt-4o',
+        temperature: 0.5,
+        maxTokens: 2000
+      })
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(body.model).toBe('gpt-4o')
+      expect(body.temperature).toBe(0.5)
+      expect(body.max_tokens).toBe(2000)
+      expect(body.messages).toEqual([
+        { role: 'system', content: 'You are helpful' },
+        { role: 'user', content: 'Hello' }
+      ])
+    })
+
+    test('returns text content by default', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: 'Plain text response' } }]
+        })
+      })
+
+      const result = await makeCompletion({
+        systemPrompt: 'sys',
+        userPrompt: 'user'
+      })
+
+      expect(result).toBe('Plain text response')
+    })
+
+    test('parses JSON when responseFormat is json', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: '{"ideas": ["one", "two"]}' } }]
+        })
+      })
+
+      const result = await makeCompletion({
+        systemPrompt: 'sys',
+        userPrompt: 'user',
+        responseFormat: 'json'
+      })
+
+      expect(result).toEqual({ ideas: ['one', 'two'] })
+
+      // Verify json mode was requested
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(body.response_format).toEqual({ type: 'json_object' })
+    })
+
+    test('throws on invalid JSON response when json format requested', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: 'not valid json' } }]
+        })
+      })
+
+      await expect(
+        makeCompletion({ systemPrompt: 'sys', userPrompt: 'user', responseFormat: 'json' })
+      ).rejects.toThrow('AI returned invalid JSON')
+    })
+
+    test('throws descriptive error for 401 status', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ error: 'Unauthorized' })
+      })
+
+      await expect(
+        makeCompletion({ systemPrompt: 'sys', userPrompt: 'user' })
+      ).rejects.toThrow('Invalid API key')
+    })
+
+    test('throws descriptive error for 429 status', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        json: () => Promise.resolve({ error: 'Too many requests' })
+      })
+
+      await expect(
+        makeCompletion({ systemPrompt: 'sys', userPrompt: 'user' })
+      ).rejects.toThrow('Rate limit exceeded')
+    })
+
+    test('throws generic error for other status codes', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: 'Internal server error' })
+      })
+
+      await expect(
+        makeCompletion({ systemPrompt: 'sys', userPrompt: 'user' })
+      ).rejects.toThrow('Internal server error')
+    })
+
+    test('handles non-JSON error response body', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: () => Promise.reject(new Error('Not JSON'))
+      })
+
+      await expect(
+        makeCompletion({ systemPrompt: 'sys', userPrompt: 'user' })
+      ).rejects.toThrow('API error: 503')
+    })
+
+    test('uses default model and parameters', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: 'ok' } }]
+        })
+      })
+
+      await makeCompletion({ systemPrompt: 'sys', userPrompt: 'user' })
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(body.model).toBe('gpt-4o')
+      expect(body.temperature).toBe(0.7)
+      expect(body.max_tokens).toBe(4000)
+    })
+  })
+
+  describe('makeStreamingCompletion', () => {
+    beforeEach(() => {
+      localStorage.getItem.mockReturnValue('sk-test-key')
+    })
+
+    function createMockStream(chunks) {
+      const encoder = new TextEncoder()
+      let index = 0
+      return {
+        getReader: () => ({
+          read: vi.fn().mockImplementation(async () => {
+            if (index >= chunks.length) {
+              return { done: true, value: undefined }
+            }
+            const chunk = chunks[index++]
+            return { done: false, value: encoder.encode(chunk) }
+          }),
+          cancel: vi.fn().mockResolvedValue(undefined)
+        })
+      }
+    }
+
+    test('streams chunks to onChunk callback', async () => {
+      const chunks = [
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":" world"}}]}\n\n',
+        'data: [DONE]\n\n'
+      ]
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        body: createMockStream(chunks)
+      })
+
+      const onChunk = vi.fn()
+      await makeStreamingCompletion(
+        { systemPrompt: 'sys', userPrompt: 'user' },
+        onChunk
+      )
+
+      expect(onChunk).toHaveBeenCalledWith('Hello')
+      expect(onChunk).toHaveBeenCalledWith(' world')
+      expect(onChunk).toHaveBeenCalledTimes(2)
+    })
+
+    test('returns abort function', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        body: createMockStream(['data: [DONE]\n\n'])
+      })
+
+      const result = await makeStreamingCompletion(
+        { systemPrompt: 'sys', userPrompt: 'user' },
+        vi.fn()
+      )
+
+      expect(typeof result).toBe('function')
+    })
+
+    test('sends request to streaming endpoint', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        body: createMockStream(['data: [DONE]\n\n'])
+      })
+
+      await makeStreamingCompletion(
+        { systemPrompt: 'sys', userPrompt: 'user' },
+        vi.fn()
+      )
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/ai/completion/stream',
+        expect.objectContaining({
+          method: 'POST',
+          signal: expect.any(AbortSignal)
+        })
+      )
+    })
+
+    test('throws on 401 error', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ error: 'Unauthorized' })
+      })
+
+      await expect(
+        makeStreamingCompletion(
+          { systemPrompt: 'sys', userPrompt: 'user' },
+          vi.fn()
+        )
+      ).rejects.toThrow('Invalid API key')
+    })
+
+    test('throws on 429 error', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        json: () => Promise.resolve({})
+      })
+
+      await expect(
+        makeStreamingCompletion(
+          { systemPrompt: 'sys', userPrompt: 'user' },
+          vi.fn()
+        )
+      ).rejects.toThrow('Rate limit exceeded')
+    })
+
+    test('continues streaming when onChunk callback throws', async () => {
+      const chunks = [
+        'data: {"choices":[{"delta":{"content":"chunk1"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"chunk2"}}]}\n\n',
+        'data: [DONE]\n\n'
+      ]
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        body: createMockStream(chunks)
+      })
+
+      const onChunk = vi.fn()
+        .mockImplementationOnce(() => { throw new Error('Callback error') })
+        .mockImplementation(() => {})
+
+      // Should not throw despite callback error
+      await makeStreamingCompletion(
+        { systemPrompt: 'sys', userPrompt: 'user' },
+        onChunk
+      )
+
+      expect(onChunk).toHaveBeenCalledTimes(2)
+    })
+
+    test('handles abort gracefully', async () => {
+      mockFetch.mockRejectedValue(Object.assign(new Error('Aborted'), { name: 'AbortError' }))
+
+      const result = await makeStreamingCompletion(
+        { systemPrompt: 'sys', userPrompt: 'user' },
+        vi.fn()
+      )
+
+      // Should return abort function, not throw
+      expect(typeof result).toBe('function')
+    })
+
+    test('throws on no API key', async () => {
+      localStorage.getItem.mockReturnValue(null)
+
+      await expect(
+        makeStreamingCompletion(
+          { systemPrompt: 'sys', userPrompt: 'user' },
+          vi.fn()
+        )
+      ).rejects.toThrow('OpenAI API key not configured')
+    })
+
+    test('skips malformed SSE data lines', async () => {
+      const chunks = [
+        'data: not-json\n\n',
+        'data: {"choices":[{"delta":{"content":"valid"}}]}\n\n',
+        'data: [DONE]\n\n'
+      ]
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        body: createMockStream(chunks)
+      })
+
+      const onChunk = vi.fn()
+      await makeStreamingCompletion(
+        { systemPrompt: 'sys', userPrompt: 'user' },
+        onChunk
+      )
+
+      expect(onChunk).toHaveBeenCalledWith('valid')
+      expect(onChunk).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('estimateTokens', () => {
+    test('estimates roughly 1 token per 4 characters', () => {
+      expect(estimateTokens('hello world')).toBe(3) // 11 chars / 4 = 2.75 → 3
+    })
+
+    test('returns 0 for empty string', () => {
+      expect(estimateTokens('')).toBe(0)
+    })
+  })
+
+  describe('isApiKeyConfigured', () => {
+    test('returns true when key is available', async () => {
+      localStorage.getItem.mockReturnValue('sk-test')
+
+      const result = await isApiKeyConfigured()
+
+      expect(result).toBe(true)
+    })
+
+    test('returns false when no key is available', async () => {
+      const result = await isApiKeyConfigured()
+
+      expect(result).toBe(false)
+    })
+  })
+})

--- a/src/services/agents/__tests__/aiService.test.js
+++ b/src/services/agents/__tests__/aiService.test.js
@@ -1,18 +1,21 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { makeCompletion, makeStreamingCompletion, estimateTokens, isApiKeyConfigured } from '../aiService'
 
-// Mock fetch globally
 const mockFetch = vi.fn()
-global.fetch = mockFetch
 
 describe('aiService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubGlobal('fetch', mockFetch)
     // Reset storage mocks
     window.secureStorage = undefined
     localStorage.getItem.mockReturnValue(null)
     // Reset import.meta.env — use delete so the value is truly absent
     delete import.meta.env.VITE_OPENAI_API_KEY
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   describe('API key retrieval', () => {


### PR DESCRIPTION
## Summary
- Add unit tests for all 5 agent contracts (brainstorm, draft, revision, editor, argument strengthener) covering execution, proposal creation, response parsing, option handling, and error paths
- Add unit tests for aiService covering the API key fallback chain, makeCompletion (text/JSON modes, HTTP error handling), makeStreamingCompletion (chunk streaming, abort, SSE parsing), estimateTokens, and isApiKeyConfigured
- Unskip the AgentContext executePipeline and executionProgress clearing tests by fixing fake timer and async state timing issues

## Test plan
- [x] All 87 new tests pass
- [x] All 7 previously skipped tests now pass
- [x] Full suite: 325 passing, 0 failures
